### PR TITLE
run fullstop as integration-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: java
-jdk:
-  - oraclejdk8
+
+sudo: true
+
+jdk: oraclejdk8
 
 services:
     - postgresql
 
 before_script:
-  - psql -c 'create database fullstop;' -U postgres
+    - psql -c 'create database fullstop;' -U postgres
 
 script: mvn clean install
 
 after_success:
-  - mvn coveralls:report -Ptravis
+    - mvn coveralls:report -Ptravis
 
 notifications:
     email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ addons:
 before_script:
   - psql -c 'CREATE DATABASE fullstop;' -U postgres
 
-script: mvn clean install
+script:
+    - mvn clean install -Pfullstop-startup
 
 after_success:
     - mvn coveralls:report -Ptravis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: java
 jdk:
   - oraclejdk8
 
+services:
+    - postgresql
+
+before_script:
+  - psql -c 'create database fullstop;' -U postgres
+
 script: mvn clean install
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ sudo: true
 
 jdk: oraclejdk8
 
-services:
-    - postgresql
+addons:
+  postgresql: "9.4"
 
 before_script:
-    - psql -c 'create database fullstop;' -U postgres
+  - psql -c 'CREATE DATABASE fullstop;' -U postgres
 
 script: mvn clean install
 

--- a/fullstop-it-autoshutdown/pom.xml
+++ b/fullstop-it-autoshutdown/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.zalando.stups</groupId>
+    <artifactId>fullstop-parent</artifactId>
+    <version>0.5.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>fullstop-it-autoshutdown</artifactId>
+  <dependencies>
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context-support</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>1.10.19</version>
+        <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/fullstop-it-autoshutdown/src/main/java/org/zalando/stups/fullstop/testing/AutoShutdown.java
+++ b/fullstop-it-autoshutdown/src/main/java/org/zalando/stups/fullstop/testing/AutoShutdown.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.fullstop.testing;
+
+import static java.lang.System.currentTimeMillis;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Value;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.support.AbstractApplicationContext;
+
+import org.springframework.scheduling.annotation.Scheduled;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author  jbellmann
+ */
+@Profile("it-with-timeout")
+@Component
+public class AutoShutdown implements ApplicationContextAware {
+
+    private final Logger LOG = LoggerFactory.getLogger(AutoShutdown.class);
+
+    private final long startupTimestamp = System.currentTimeMillis();
+    private long timeOutInMilliseconds = 0;
+
+    private AbstractApplicationContext aac = null;
+
+    @Value("${fullstop.autoshutdown.timeout:2}")
+    protected int timeout;
+
+    @PostConstruct
+    public void init() {
+        timeOutInMilliseconds = TimeUnit.MILLISECONDS.convert(timeout, TimeUnit.MINUTES);
+    }
+
+    @Scheduled(initialDelay = 10 * 1000, fixedDelay = 10 * 1000)
+    public void shutdown() {
+        LOG.warn("CHECK FOR AUTOSHUTDOWN, TIMEOUT WAS SET TO {} MIN", timeout);
+
+        long diff = currentTimeMillis() - timeOutInMilliseconds;
+        if (diff > startupTimestamp) {
+            LOG.warn("CLOSE APPLICATION_CONTEX FOR AUTOSHUTDOWN");
+            this.aac.close();
+        } else {
+            LOG.warn("CHECK FOR AUTOSHUTDOWN, DIFF : {} ms", startupTimestamp - diff);
+        }
+    }
+
+    @Override
+    public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
+        this.aac = (AbstractApplicationContext) applicationContext;
+    }
+}

--- a/fullstop-it-autoshutdown/src/test/java/org/zalando/stups/fullstop/testing/AutoShutdownTest.java
+++ b/fullstop-it-autoshutdown/src/test/java/org/zalando/stups/fullstop/testing/AutoShutdownTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.fullstop.testing;
+
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import org.springframework.context.support.AbstractApplicationContext;
+
+public class AutoShutdownTest {
+
+    @Test
+    public void simpleTest() throws InterruptedException {
+        AbstractApplicationContext acc = mock(AbstractApplicationContext.class);
+        AutoShutdown shutdown = new AutoShutdown();
+        shutdown.setApplicationContext(acc);
+        shutdown.timeout = 1;
+        shutdown.init();
+
+        for (int i = 0; i < 10; i++) {
+
+            shutdown.shutdown();
+            TimeUnit.SECONDS.sleep(8);
+        }
+
+        verify(acc, atLeast(1)).close();
+    }
+}

--- a/fullstop-it/config/application.yml
+++ b/fullstop-it/config/application.yml
@@ -33,9 +33,9 @@ spring:
         resource:
             tokenInfoUri: https://example.com/oauth/tokeninfo
     datasource:
-        url: jdbc:postgresql://localhost:5435/fullstop
+        url: jdbc:postgresql://localhost:5432/fullstop
         username: postgres
-        password: postgres
+        password: 
         driver-class-name: org.postgresql.Driver
 #    jpa:
 #        hibernate:

--- a/fullstop-it/config/application.yml
+++ b/fullstop-it/config/application.yml
@@ -1,0 +1,154 @@
+management:
+    context-path: /spring-endpoints
+
+endpoints:
+    health:
+        sensitive: true
+
+# defaults values for info endpoints
+project:
+    artifactId: fullstop
+    name: Fullstop
+    version: X.X.X.X
+    description: Audit reporting application
+
+# values from maven
+info:
+    app:
+        artifact: fullstop
+        name: Fullstop
+        description: Audit reporting application
+        version: XXXX
+
+spring:
+    # JACKSON (JacksonProperties)
+    jackson:
+        property-naming-strategy: CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES
+        date-format: com.fasterxml.jackson.databind.util.ISO8601DateFormat
+        serialization:
+              write-dates-as-timestamps: false
+        deserialization:
+            fail-on-unknown-properties: false
+    oauth2:
+        resource:
+            tokenInfoUri: https://example.com/oauth/tokeninfo
+    datasource:
+        url: jdbc:postgresql://localhost:5435/fullstop
+        username: postgres
+        password: postgres
+        driver-class-name: org.postgresql.Driver
+#    jpa:
+#        hibernate:
+#            ddl-auto: create-drop
+#        show-sql: true
+# Uncomment the above statements for debugging. This will drop and recreate a schema everytime you restart Fullstop.
+
+fullstop:
+
+    logging:
+        dir: ${java.io.tmpdir}/fullstop_logs
+
+    container:
+        autoStart: false
+
+    processor:
+        properties:
+            # The sqs url where you wish to pull CloudTrail notification from (required)
+            sqsUrl: https://sqs.us-west-1.amazonaws.com/1234567890/fullstop
+
+            # The SQS end point specific to a region
+            sqsRegion: us-west-1
+
+            # A period of time during which Amazon SQS prevents other consuming components
+            # from receiving and processing that message
+            visibilityTimeout: 60
+
+            # The S3 end point specific to a region
+            s3Region: us-west-1
+
+            # Number of threads to download S3 files in parallel when you enable thread mode
+            threadCount: 1
+
+            # The duration in seconds to wait for thread pool termination before issue shutDownNow
+            threadTerminationDelaySeconds: 60
+
+            # Max number of AWSCloudTrailEvent that buffered before emit. EagleEye may emit 0 events
+            maxEventsPerEmit: 10
+
+            # Whether to include raw event in CloudTrailEventMetadata
+            enableRawEventInfo: false
+    instanceData:
+      # Bucket, where USER_DATA and AUDIT_LOG will be stored
+      bucketName: anBucketName
+
+    plugins:
+        properties:
+            # The bucket, where our enriched data will be stored
+            s3bucket: anotherBucketName
+
+        region:
+            # The whitelist of regions
+            whitelistedRegions:
+              - 'us-west-1'
+              - 'us-east-1'
+
+        ami:
+            # Account containing whitelisted AMI
+            whitelistedAmiAccount: 123456,2345678,34567890
+            amiNameStartWith: aPrefix
+
+        kio:
+            url: https://example.com/kio/api
+
+        pierone:
+            url: https://example.com/pierone/api
+
+        registry:
+            defaultMandatoryApprovals:
+              - SPECIFICATION
+              - CODE_CHANGE
+              - TEST
+              - DEPLOY
+            mandatoryApprovals: ${FULLSTOP_MANDATORY_APPROVALS}
+            defaultApprovalsFromMany:
+              - CODE_CHANGE
+              - TEST
+              - DEPLOY
+            approvalsFromMany: ${FULLSTOP_APPROVALS_FROM_MANY}
+
+    clients:
+        kio:
+            url: https://example.com/kio/api
+
+        pierone:
+            url: https://example.com/pierone/api
+
+        teamService:
+            url: https://example.com/teams/api
+
+#
+# OAuth2
+#
+tokens:
+    accessTokenUri: https://example.com/oauth/accesstoken
+    credentialsDirectory: ${user.dir}/credentials
+    autoStartup: false
+
+    token-configuration-list:
+        - tokenId: kio
+          scopes:
+              - uid
+        - tokenId: pierone
+          scopes:
+              - uid
+
+
+javax:
+    persistence:
+        validation:
+            # force validation - fail fast if something goes wrong
+            mode: CALLBACK
+            group:
+                pre-update: javax.validation.groups.Default,org.zalando.stups.fullstop.violation.domain.validation.groups.PersistenceOnly
+                pre-persist: javax.validation.groups.Default,org.zalando.stups.fullstop.violation.domain.validation.groups.PersistenceOnly
+                pre-remove: javax.validation.groups.Default,org.zalando.stups.fullstop.violation.domain.validation.groups.PersistenceOnly

--- a/fullstop-it/pom.xml
+++ b/fullstop-it/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.zalando.stups</groupId>
+        <artifactId>fullstop-parent</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>fullstop-it</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fullstop-it-autoshutdown</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fullstop</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <configuration>
+                    <executable>java</executable>
+                    <arguments>
+                        <argument>-classpath</argument>
+                        <classpath/>
+                        <argument>org.zalando.stups.fullstop.Fullstop</argument>
+                        <argument>--spring.config.location=${basedir}/config</argument>
+                        <argument>--spring.profiles.active=it-with-timeout</argument>
+                        <argument>--debug</argument>
+                    </arguments>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/fullstop-it/pom.xml
+++ b/fullstop-it/pom.xml
@@ -21,32 +21,37 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.4.0</version>
-                <configuration>
-                    <executable>java</executable>
-                    <arguments>
-                        <argument>-classpath</argument>
-                        <classpath/>
-                        <argument>org.zalando.stups.fullstop.Fullstop</argument>
-                        <argument>--spring.config.location=${basedir}/config</argument>
-                        <argument>--spring.profiles.active=it-with-timeout</argument>
-                        <argument>--debug</argument>
-                    </arguments>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <profile>
+            <id>fullstop-startup</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.4.0</version>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>org.zalando.stups.fullstop.Fullstop</argument>
+                                <argument>--spring.config.location=${basedir}/config</argument>
+                                <argument>--spring.profiles.active=it-with-timeout</argument>
+                                <argument>--debug</argument>
+                            </arguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>pre-integration-test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/fullstop/pom.xml
+++ b/fullstop/pom.xml
@@ -162,7 +162,7 @@
         <dependency>
             <groupId>org.zalando.stups</groupId>
             <artifactId>spring-boot-zalando-stups-tokens</artifactId>
-            <version>0.6.0</version>
+            <version>0.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.zalando.stups</groupId>

--- a/fullstop/src/main/java/org/zalando/stups/fullstop/Fullstop.java
+++ b/fullstop/src/main/java/org/zalando/stups/fullstop/Fullstop.java
@@ -15,21 +15,29 @@
  */
 package org.zalando.stups.fullstop;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.data.web.config.EnableSpringDataWebSupport;
-import org.springframework.plugin.core.config.EnablePluginRegistries;
-import org.springframework.security.config.annotation.web.servlet.configuration.EnableWebMvcSecurity;
-import org.zalando.stups.fullstop.plugin.FullstopPlugin;
-
 import javax.annotation.PostConstruct;
 
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import org.springframework.plugin.core.config.EnablePluginRegistries;
+
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import org.springframework.security.config.annotation.web.servlet.configuration.EnableWebMvcSecurity;
+
+import org.zalando.stups.fullstop.plugin.FullstopPlugin;
+
 /**
- * @author jbellmann
+ * @author  jbellmann
  */
 @Configuration
 @ComponentScan
@@ -38,6 +46,7 @@ import javax.annotation.PostConstruct;
 @EnableJpaRepositories("org.zalando.stups.fullstop.violation.repository")
 @EnableWebMvcSecurity
 @EnableSpringDataWebSupport
+@EnableScheduling
 public class Fullstop {
 
     @Autowired

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
         <module>fullstop-violation-sink</module>
         <module>fullstop-violation-sink-reactor</module>
         <module>fullstop-violation-persister-jpa</module>
+        <module>fullstop-it</module>
+        <module>fullstop-it-autoshutdown</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
The idea is to startup 'fullstop' without spring-boot-maven-plugin to see that configurations and autowiring work as expected. This is not an final solution but it works for the moment. Maybe we should bake it into it's own profile to skip this on some builds.

Easiest way to make sure that a minimum is working.
- Event-Processor is off
- OAuth2-Token-Refresh is off

Shutdown initiated after 2 min by default, but configurable.