### PR TITLE
#333 handle unique constraint violations on lifecycle save

### DIFF
--- a/fullstop-job-launcher/src/main/resources/log4j2.xml
+++ b/fullstop-job-launcher/src/main/resources/log4j2.xml
@@ -8,6 +8,7 @@
 
     <Loggers>
         <Logger name="org.zalando.stups" level="info"/>
+        <Logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="OFF" />
 
         <Root level="info">
             <AppenderRef ref="Console"/>

--- a/fullstop-logging/src/main/resources/log4j2.xml
+++ b/fullstop-logging/src/main/resources/log4j2.xml
@@ -8,6 +8,7 @@
 
     <Loggers>
         <Logger name="org.zalando.stups.fullstop" level="debug"/>
+        <Logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="OFF" />
 
         <Root level="info">
             <AppenderRef ref="Console"/>

--- a/fullstop-violation/fullstop-violation-jpa/pom.xml
+++ b/fullstop-violation/fullstop-violation-jpa/pom.xml
@@ -118,6 +118,27 @@
                 <artifactId>apt-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-assertions</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packages>
+                        <package>org.zalando.stups.fullstop.violation.entity</package>
+                    </packages>
+                    <excludes>
+                        <!-- exclude querydsl's Q classes -->
+                        <exclude>[a-z0-9.]+Q[A-Z].*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>

--- a/fullstop-violation/fullstop-violation-jpa/src/main/java/org/zalando/stups/fullstop/jpa/auditing/SpringSecurityAuditorAware.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/main/java/org/zalando/stups/fullstop/jpa/auditing/SpringSecurityAuditorAware.java
@@ -20,10 +20,7 @@ public final class SpringSecurityAuditorAware implements AuditorAware<String> {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null) {
             return "FULLSTOP";
-        }
-        else {
-            Assert.notNull(authentication, "Current authentication is null; could not gather user details from it");
-
+        } else {
             final String userName = authentication.getName();
             logger.trace("Found Auditor: {}", userName);
 

--- a/fullstop-violation/fullstop-violation-jpa/src/main/java/org/zalando/stups/fullstop/violation/repository/LifecycleRepository.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/main/java/org/zalando/stups/fullstop/violation/repository/LifecycleRepository.java
@@ -12,6 +12,6 @@ import org.zalando.stups.fullstop.violation.entity.VersionEntity;
 @Repository
 public interface LifecycleRepository extends JpaRepository<LifecycleEntity, Long> {
 
-    LifecycleEntity findByInstanceIdAndApplicationEntityAndVersionEntityAndRegion(String instanceId,
-            ApplicationEntity applicationEntity, VersionEntity versionEntity, String region);
+    LifecycleEntity findByInstanceIdAndApplicationEntityAndVersionEntityAndRegionAndAccountId(String instanceId,
+                                                                                              ApplicationEntity applicationEntity, VersionEntity versionEntity, String region, String accountId);
 }

--- a/fullstop-violation/fullstop-violation-jpa/src/main/java/org/zalando/stups/fullstop/violation/service/impl/ApplicationLifecycleServiceImpl.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/main/java/org/zalando/stups/fullstop/violation/service/impl/ApplicationLifecycleServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 import org.yaml.snakeyaml.Yaml;
 import org.zalando.stups.fullstop.violation.entity.ApplicationEntity;
 import org.zalando.stups.fullstop.violation.entity.LifecycleEntity;
@@ -24,6 +25,7 @@ import javax.transaction.Transactional;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import static javax.transaction.Transactional.TxType.REQUIRES_NEW;
 
@@ -34,6 +36,8 @@ import static javax.transaction.Transactional.TxType.REQUIRES_NEW;
 public class ApplicationLifecycleServiceImpl implements ApplicationLifecycleService {
 
     protected static final String BEAN_NAME = "applicationLifecycleService";
+
+    private final Base64.Decoder base64Decoder = Base64.getMimeDecoder();
 
     private final Logger log = LoggerFactory.getLogger(ApplicationLifecycleServiceImpl.class);
 
@@ -56,16 +60,12 @@ public class ApplicationLifecycleServiceImpl implements ApplicationLifecycleServ
     @Transactional(REQUIRES_NEW)
     public LifecycleEntity saveLifecycle(final ApplicationEntity applicationEntity, final VersionEntity versionEntity,
             final LifecycleEntity lifecycleEntity) {
-
-        if (applicationEntity == null || versionEntity == null || lifecycleEntity == null) {
-            throw new RuntimeException("saveLifecycle: One or more parameters are null!");
-        }
+        Assert.notNull(applicationEntity, "applicationEntity must not be null");
+        Assert.notNull(versionEntity, "versionEntity must not be null");
+        Assert.notNull(lifecycleEntity, "lifecycleEntity must not be null");
 
         ApplicationEntity applicationByName = applicationRepository.findByName(applicationEntity.getName());
         VersionEntity versionByName = versionRepository.findByName(versionEntity.getName());
-        LifecycleEntity lifecycleByInstanceId =
-                lifecycleRepository.findByInstanceIdAndApplicationEntityAndVersionEntityAndRegion(
-                        lifecycleEntity.getInstanceId(), applicationByName, versionByName, lifecycleEntity.getRegion());
 
         if (applicationByName == null) {
             applicationByName = applicationRepository.save(applicationEntity);
@@ -74,6 +74,16 @@ public class ApplicationLifecycleServiceImpl implements ApplicationLifecycleServ
         if (versionByName == null) {
             versionByName = versionRepository.save(versionEntity);
         }
+
+        if (!applicationByName.getVersionEntities().contains(versionByName)) {
+            applicationByName.getVersionEntities().add(versionByName);
+            applicationByName = applicationRepository.save(applicationByName);
+        }
+
+
+        LifecycleEntity lifecycleByInstanceId =
+                lifecycleRepository.findByInstanceIdAndApplicationEntityAndVersionEntityAndRegionAndAccountId(
+                        lifecycleEntity.getInstanceId(), applicationByName, versionByName, lifecycleEntity.getRegion(), lifecycleEntity.getAccountId());
 
         if (lifecycleByInstanceId != null) {
             lifecycleByInstanceId.setEventDate(lifecycleEntity.getEventDate());
@@ -84,44 +94,46 @@ public class ApplicationLifecycleServiceImpl implements ApplicationLifecycleServ
             return lifecycleByInstanceId;
         }
 
-        if (!applicationByName.getVersionEntities().contains(versionByName)) {
-            applicationByName.getVersionEntities().add(versionByName);
-            applicationRepository.save(applicationByName);
-        }
-
         lifecycleEntity.setApplicationEntity(applicationByName);
         lifecycleEntity.setVersionEntity(versionByName);
 
-        LifecycleEntity savedLifecycleEntity = lifecycleRepository.save(lifecycleEntity);
-        return savedLifecycleEntity;
+        return lifecycleRepository.save(lifecycleEntity);
     }
 
     @Override
     public LifecycleEntity saveInstanceLogLifecycle(final String instanceId, final DateTime instanceBootTime,
             final String userdataPath, final String region, final String logData, final String accountId) {
-        if (logData == null) {
-            log.warn("Logdata must not be null!");
+        final Yaml yaml = new Yaml();
+        final Optional<Map> taupageYaml = Optional.ofNullable(logData)
+                .map(base64Decoder::decode)
+                .map(String::new)
+                .map(yaml::load)
+                .map(map -> (Map) map);
+
+        final Optional<ApplicationEntity> application = taupageYaml
+                .map(yamlMap -> yamlMap.get("application_id"))
+                .map(String::valueOf)
+                .map(ApplicationEntity::new);
+
+        final Optional<VersionEntity> version = taupageYaml
+                .map(yamlMap -> yamlMap.get("application_version"))
+                .map(String::valueOf)
+                .map(VersionEntity::new);
+
+        if (application.isPresent() && version.isPresent()) {
+            final LifecycleEntity lifecycleEntity = new LifecycleEntity();
+            lifecycleEntity.setInstanceBootTime(instanceBootTime);
+            lifecycleEntity.setInstanceId(instanceId);
+            lifecycleEntity.setAccountId(accountId);
+            lifecycleEntity.setRegion(region);
+            lifecycleEntity.setUserdataPath(userdataPath);
+
+            return self.saveLifecycle(application.get(), version.get(), lifecycleEntity);
+        } else {
+            log.warn("Empty or invalid taupage yaml.");
             return null;
         }
-        Yaml yaml = new Yaml();
-        String decodedLogData = new String(Base64.getMimeDecoder().decode(logData));
 
-        Map userdata = (Map) yaml.load(decodedLogData);
-
-        ApplicationEntity applicationEntity = new ApplicationEntity(userdata.get("application_id").toString());
-
-        VersionEntity versionEntity = new VersionEntity(userdata.get("application_version").toString());
-
-        LifecycleEntity lifecycleEntity = new LifecycleEntity();
-        lifecycleEntity.setInstanceBootTime(instanceBootTime);
-        lifecycleEntity.setInstanceId(instanceId);
-        lifecycleEntity.setAccountId(accountId);
-        lifecycleEntity.setRegion(region);
-        lifecycleEntity.setUserdataPath(userdataPath);
-
-        LifecycleEntity savedLifecycleEntity = self.saveLifecycle(applicationEntity, versionEntity, lifecycleEntity);
-
-        return savedLifecycleEntity;
     }
 
     @Override

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/EmbeddedPostgresJpaConfig.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/EmbeddedPostgresJpaConfig.java
@@ -5,13 +5,10 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.orm.jpa.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.retry.annotation.EnableRetry;
-import org.zalando.stups.fullstop.violation.service.ApplicationLifecycleService;
-import org.zalando.stups.fullstop.violation.service.impl.ApplicationLifecycleServiceImpl;
 
 import javax.sql.DataSource;
 import java.io.IOException;
@@ -37,10 +34,5 @@ public class EmbeddedPostgresJpaConfig {
     @Bean
     AuditorAware<String> auditorAware() {
         return () -> "unit-test";
-    }
-
-    @Bean
-    ApplicationLifecycleService applicationLifecycleService() {
-        return new ApplicationLifecycleServiceImpl();
     }
 }

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/EmbeddedPostgresJpaConfig.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/EmbeddedPostgresJpaConfig.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.orm.jpa.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.retry.annotation.EnableRetry;
 import org.zalando.stups.fullstop.violation.service.ApplicationLifecycleService;
 import org.zalando.stups.fullstop.violation.service.impl.ApplicationLifecycleServiceImpl;
 
@@ -19,6 +21,7 @@ import java.io.IOException;
 @EnableJpaRepositories("org.zalando.stups.fullstop.violation.repository")
 @EntityScan("org.zalando.stups.fullstop.violation")
 @EnableJpaAuditing
+@EnableRetry(proxyTargetClass = true)
 public class EmbeddedPostgresJpaConfig {
 
     @Bean

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/service/impl/ApplicationLifecycleServiceImplTest.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/service/impl/ApplicationLifecycleServiceImplTest.java
@@ -1,14 +1,19 @@
 package org.zalando.stups.fullstop.violation.service.impl;
 
 import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.zalando.stups.fullstop.violation.EmbeddedPostgresJpaConfig;
 import org.zalando.stups.fullstop.violation.entity.ApplicationEntity;
+import org.zalando.stups.fullstop.violation.entity.Assertions;
 import org.zalando.stups.fullstop.violation.entity.LifecycleEntity;
 import org.zalando.stups.fullstop.violation.entity.VersionEntity;
 import org.zalando.stups.fullstop.violation.repository.ApplicationRepository;
@@ -16,217 +21,224 @@ import org.zalando.stups.fullstop.violation.repository.LifecycleRepository;
 import org.zalando.stups.fullstop.violation.repository.VersionRepository;
 import org.zalando.stups.fullstop.violation.service.ApplicationLifecycleService;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.transaction.Transactional;
 import java.util.Base64;
+import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.joda.time.DateTime.now;
+import static org.mockito.Mockito.*;
 
-/**
- * Created by gkneitschel.
- */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = EmbeddedPostgresJpaConfig.class)
-@Transactional
+@ContextConfiguration
 public class ApplicationLifecycleServiceImplTest {
 
-    private VersionEntity snapshot;
-
-    private VersionEntity snapshot2;
-
-    private VersionEntity release;
-
-    private ApplicationEntity fullstop;
-
-    private ApplicationEntity fullstop2;
-
-    private LifecycleEntity runInstance;
-
-    private LifecycleEntity stopInstance;
+    private static final String ACCOUNT_ID = "111222333444";
+    private static final String REGION = "eu-west-1";
+    private static final List<String> INSTANCE_IDS = asList("i1", "i2", "i3");
+    private static final String INSTANCE_ID = "i1";
+    private static final DateTime INSTANCE_BOOT_TIME = now();
+    private static final String USERDATA_PATH = "path/to/the/logs";
 
     @Autowired
-    private ApplicationLifecycleService applicationLifecycleService;
+    private ApplicationRepository mockApplicationRepository;
+    @Autowired
+    private VersionRepository mockVersionRepository;
+    @Autowired
+    private LifecycleRepository mockLifecycleRepository;
+    @Autowired
+    @Qualifier(ApplicationLifecycleServiceImpl.BEAN_NAME)
+    private ApplicationLifecycleService mockApplicationLifecycleService;
 
     @Autowired
-    private VersionRepository versionRepository;
+    private ApplicationLifecycleService applicationLifecycleServiceImpl;
 
-    @Autowired
-    private ApplicationRepository applicationRepository;
+    private ApplicationEntity helloWorldApplication;
 
-    @Autowired
-    private LifecycleRepository lifecycleRepository;
-
-    @PersistenceContext
-    private EntityManager em;
+    private String applicationId = "fullstop";
+    private String versionId = "1.0";
+    private LifecycleEntity lifecycle;
+    private ApplicationEntity application;
+    private VersionEntity version;
 
     @Before
     public void setUp() throws Exception {
-        snapshot = new VersionEntity("0.5-Snaphot");
-        snapshot2 = new VersionEntity("0.5-Snaphot");
-        release = new VersionEntity("1.0");
+        reset(mockApplicationRepository, mockVersionRepository, mockLifecycleRepository, mockApplicationLifecycleService);
 
-        fullstop = new ApplicationEntity("Fullstop");
-        fullstop2 = new ApplicationEntity("Fullstop");
+        helloWorldApplication = new ApplicationEntity("hello-world");
+        when(mockApplicationRepository.findByInstanceIds(anyString(), anyString(), anyCollectionOf(String.class)))
+                .thenReturn(helloWorldApplication);
 
-        runInstance = new LifecycleEntity();
-        runInstance.setRegion("eu-west-1");
-        runInstance.setEventDate(new DateTime());
-        runInstance.setInstanceId("i-1234");
-        runInstance.setEventType("RunInstances");
+        lifecycle = new LifecycleEntity();
+        when(mockApplicationLifecycleService.saveLifecycle(any(), any(), any())).then(invocationOnMock -> {
+            final Object[] args = invocationOnMock.getArguments();
+            final ApplicationEntity applicationArg = (ApplicationEntity) args[0];
+            final VersionEntity versionArg = (VersionEntity) args[1];
+            final LifecycleEntity lifecycleArg = (LifecycleEntity) args[2];
+            lifecycleArg.setApplicationEntity(applicationArg);
+            lifecycleArg.setVersionEntity(versionArg);
+            return lifecycleArg;
+        });
 
-        LifecycleEntity terminteInstance = new LifecycleEntity();
-        terminteInstance.setEventDate(new DateTime());
-        terminteInstance.setEventType("TerminateInstances");
-        terminteInstance.setRegion("eu-central-1");
-        terminteInstance.setInstanceId("i-7890");
+        when(mockApplicationRepository.save(any(ApplicationEntity.class))).then(returnFirstArgument());
+        when(mockVersionRepository.save(any(VersionEntity.class))).then(returnFirstArgument());
+        when(mockLifecycleRepository.save(any(LifecycleEntity.class))).then(returnFirstArgument());
 
-        stopInstance = new LifecycleEntity();
-        stopInstance.setEventDate(new DateTime());
-        stopInstance.setEventType("StopInstances");
-        stopInstance.setInstanceId("i-7890");
-        stopInstance.setRegion("eu-north-8");
+        application = new ApplicationEntity(applicationId);
+        version = new VersionEntity(versionId);
+    }
 
+    private Answer<?> returnFirstArgument() {
+        return invocationOnMock -> invocationOnMock.getArguments()[0];
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        verifyNoMoreInteractions(mockApplicationRepository, mockVersionRepository, mockLifecycleRepository, mockApplicationLifecycleService);
     }
 
     @Test
-    public void testSave() throws Exception {
+    public void testSaveLifecycleWithNewAppAndVersion() throws Exception {
+        final LifecycleEntity lifecycle = new LifecycleEntity();
+        lifecycle.setInstanceId(INSTANCE_ID);
+        lifecycle.setAccountId(ACCOUNT_ID);
+        lifecycle.setRegion(REGION);
 
-        fullstop = applicationRepository.save(fullstop);
-        snapshot.getApplicationEntities().add(fullstop);
-        snapshot = versionRepository.save(snapshot);
+        final LifecycleEntity savedLifecycle = applicationLifecycleServiceImpl.saveLifecycle(
+                application,
+                version,
+                lifecycle);
 
-        applicationLifecycleService.saveLifecycle(fullstop2, snapshot2, stopInstance);
-        assertThat(versionRepository.findAll()).isNotEmpty().hasSize(1);
+        verify(mockApplicationRepository).findByName(eq(applicationId));
+        verify(mockVersionRepository).findByName(eq(versionId));
+        verify(mockLifecycleRepository).findByInstanceIdAndApplicationEntityAndVersionEntityAndRegionAndAccountId(eq(INSTANCE_ID), eq(application), eq(version), eq(REGION), eq(ACCOUNT_ID));
+
+        verify(mockApplicationRepository, times(2)).save(eq(application));
+        verify(mockVersionRepository).save(eq(version));
+        verify(mockLifecycleRepository).save(same(lifecycle));
+
+        Assertions.assertThat(savedLifecycle).hasApplicationEntity(application);
+        Assertions.assertThat(savedLifecycle).hasVersionEntity(version);
+        Assertions.assertThat(savedLifecycle.getApplicationEntity()).hasOnlyVersionEntities(version);
     }
 
     @Test
-    public void testSaveAttachVersionToApplication() throws Exception {
-        release = versionRepository.save(release);
+    public void testSaveExistingLifecycle() throws Exception {
+        final ApplicationEntity existingApp = new ApplicationEntity(applicationId);
+        final VersionEntity existingVersion = new VersionEntity(versionId);
+        existingApp.getVersionEntities().add(existingVersion);
+        final LifecycleEntity existingLifecycle = new LifecycleEntity();
 
-        fullstop.getVersionEntities().add(release);
-        fullstop = applicationRepository.save(fullstop);
+        when(mockApplicationRepository.findByName(eq(applicationId))).thenReturn(existingApp);
+        when(mockVersionRepository.findByName(eq(versionId))).thenReturn(existingVersion);
+        when(mockLifecycleRepository.findByInstanceIdAndApplicationEntityAndVersionEntityAndRegionAndAccountId(anyString(), any(), any(), anyString(), anyString()))
+                .thenReturn(existingLifecycle);
 
-        em.flush();
-        em.clear();
+        final LifecycleEntity lifecycle = new LifecycleEntity();
+        lifecycle.setInstanceId(INSTANCE_ID);
+        lifecycle.setAccountId(ACCOUNT_ID);
+        lifecycle.setRegion(REGION);
 
-        VersionEntity versionEntity = versionRepository.findOne(release.getId());
-        assertThat(versionEntity.getApplicationEntities()).isNotEmpty().hasSize(1);
+        final LifecycleEntity savedLifecycle = applicationLifecycleServiceImpl.saveLifecycle(
+                application,
+                version,
+                lifecycle);
+
+        verify(mockApplicationRepository).findByName(eq(applicationId));
+        verify(mockVersionRepository).findByName(eq(versionId));
+        verify(mockLifecycleRepository).findByInstanceIdAndApplicationEntityAndVersionEntityAndRegionAndAccountId(eq(INSTANCE_ID), eq(application), eq(version), eq(REGION), eq(ACCOUNT_ID));
+        verify(mockLifecycleRepository).save(same(existingLifecycle));
+
+        Assertions.assertThat(savedLifecycle).isEqualTo(existingLifecycle);
     }
+
 
     @Test
-    public void testSaveMultipleLifecycle() throws Exception {
-        applicationLifecycleService.saveLifecycle(fullstop, snapshot, runInstance);
-        applicationLifecycleService.saveLifecycle(fullstop2, snapshot2, stopInstance);
-        assertThat(versionRepository.findAll()).isNotEmpty().hasSize(1);
-        assertThat(applicationRepository.findAll()).isNotEmpty().hasSize(1);
-        assertThat(lifecycleRepository.findAll()).isNotEmpty().hasSize(2);
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void testSaveWithLifecyleNull() {
-        applicationLifecycleService.saveLifecycle(fullstop, snapshot, null);
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void testSaveWithVersionNull() {
-        applicationLifecycleService.saveLifecycle(fullstop, null, runInstance);
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void testSaveWithApplicationNull() {
-        applicationLifecycleService.saveLifecycle(null, snapshot, runInstance);
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void testSaveAllNull() {
-        applicationLifecycleService.saveLifecycle(null, null, null);
-    }
-
-    @Test
-    public void testSaveInstanceLogLifecycle() throws Exception {
-        String userdataPath = "URL/to/File";
-        DateTime instanceBootTime = DateTime.now();
-        String instanceId = "i-1234";
-        String region = "eu-west-1";
-        String accountId = "123456";
+    public void testSaveInstanceLogs() throws Exception {
         String userdata = encodeToBase64(
                 "#taupage-ami-config\n"
-                        + "application_id: Fullstop\n"
-                        + "application_version: '0.5-Snaphot'\n"
+                        + "application_id: '" + applicationId + "'\n"
+                        + "application_version: '" + versionId + "'\n"
                         + "environment:\n"
                         + "  xx: xx");
-        LifecycleEntity lifecycleEntity = applicationLifecycleService.saveInstanceLogLifecycle(
-                instanceId,
-                instanceBootTime,
-                userdataPath, region, userdata, accountId);
-        assertThat(lifecycleEntity.getId()).isNotNull();
 
+        final LifecycleEntity result = applicationLifecycleServiceImpl.saveInstanceLogLifecycle(INSTANCE_ID, INSTANCE_BOOT_TIME, USERDATA_PATH, REGION, userdata, ACCOUNT_ID);
+        Assertions.assertThat(result)
+                .hasInstanceId(INSTANCE_ID)
+                .hasInstanceBootTime(INSTANCE_BOOT_TIME)
+                .hasUserdataPath(USERDATA_PATH)
+                .hasAccountId(ACCOUNT_ID)
+                .hasRegion(REGION)
+                .hasApplicationEntity(new ApplicationEntity(applicationId))
+                .hasVersionEntity(new VersionEntity(versionId));
+
+        verify(mockApplicationLifecycleService).saveLifecycle(any(), any(), any());
     }
+
     @Test
-    public void testSaveNullInstanceLogLifecycle() throws Exception {
-        String userdataPath = "URL/to/File";
-        DateTime instanceBootTime = DateTime.now();
-        String instanceId = "i-1234";
-        String region = "eu-west-1";
-        String accountId = "123456";
-        LifecycleEntity lifecycleEntity = applicationLifecycleService.saveInstanceLogLifecycle(
-                instanceId,
-                instanceBootTime,
-                userdataPath, region, null, accountId);
-        assertThat(lifecycleEntity).isNull();
+    public void testSaveInstanceLogsMissingAppId() throws Exception {
+        String userdata = encodeToBase64(
+                "#taupage-ami-config\n"
+                        + "application_version: '" + versionId + "'\n"
+                        + "environment:\n"
+                        + "  xx: xx");
 
+        final LifecycleEntity result = applicationLifecycleServiceImpl.saveInstanceLogLifecycle("i1", now(), "path/to/the/logs", REGION, userdata, ACCOUNT_ID);
+        assertThat(result).isNull();
     }
 
-    private String encodeToBase64(String toEncode) {
+    @Test
+    public void testSaveInstanceLogsMissingAppVersion() throws Exception {
+        String userdata = encodeToBase64(
+                "#taupage-ami-config\n"
+                        + "application_id: '" + applicationId + "'\n"
+                        + "environment:\n"
+                        + "  xx: xx");
+
+        final LifecycleEntity result = applicationLifecycleServiceImpl.saveInstanceLogLifecycle("i1", now(), "path/to/the/logs", REGION, userdata, ACCOUNT_ID);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void testFindAppByInstanceIds() throws Exception {
+        final ApplicationEntity result = applicationLifecycleServiceImpl.findAppByInstanceIds(ACCOUNT_ID, REGION, INSTANCE_IDS);
+
+        assertThat(result).isEqualTo(helloWorldApplication);
+
+        verify(mockApplicationRepository).findByInstanceIds(eq(ACCOUNT_ID), eq(REGION), eq(INSTANCE_IDS));
+    }
+
+    private static String encodeToBase64(String toEncode) {
         return Base64.getEncoder().encodeToString(
                 (toEncode).getBytes());
     }
 
-    @Test
-    public void testSaveInstanceLogLifecycle1() throws Exception {
-        String userdataPath = "URL/to/File";
-        DateTime instanceBootTime = DateTime.now();
-        String instanceId = "i-1234";
-        String region = "eu-west-1";
-        String accountId = "123456";
-        String userdata = encodeToBase64(
-                "#taupage-ami-config\n"
-                        + "application_id: Fullstop\n"
-                        + "application_version: '0.5-Snaphot'\n"
-                        + "environment:\n"
-                        + "  xx: xx");
-        applicationLifecycleService.saveInstanceLogLifecycle(
-                instanceId,
-                instanceBootTime,
-                userdataPath, region, userdata, accountId);
+    @Configuration
+    static class TestConfig {
 
-        applicationLifecycleService.saveLifecycle(fullstop, snapshot, runInstance);
-        assertThat(lifecycleRepository.findAll()).hasSize(1);
+        @Bean
+        ApplicationLifecycleService applicationLifecycleServiceImpl() {
+            return new ApplicationLifecycleServiceImpl();
+        }
 
-    }
+        @Bean(name = ApplicationLifecycleServiceImpl.BEAN_NAME)
+        ApplicationLifecycleService mockApplicationLifecycleService() {
+            return mock(ApplicationLifecycleService.class);
+        }
 
-    @Test
-    public void testBase64withNewlines() throws Exception {
-        String userdataPath = "URL/to/File";
-        DateTime instanceBootTime = DateTime.now();
-        String instanceId = "i-1234";
-        String region = "eu-west-1";
-        String accountId = "123456";
-        String userdata = "YXBwbGljYXRpb25faWQ6IENyYXp5IEFwcGxpY2F0aW9uCmFwcGxpY2F0aW9uX3ZlcnNpb246ICc\n"
-                +"xLVNOQVBTSE9UJwplbnZpcm9ubWVudDoge0VOVlZBUjogY29udGVudH0KaW5zdGFuY2VfbG9nc1\n"
-                +"91cmw6IGh0dHBzOi8vc2VydmVyLnRsZC9wYXRoL3RvL2VuZHBvaW50Cm5vdGlmeV9jZm46IHtyZ\n"
-                +"XNvdXJjZTogQXBwU2VydmVyLCBzdGFjazogY3JhenktYXBwbGljYXRpb24tMS1zbmFwc2hvdH0K\n"
-                +"cG9ydHM6IHsxMjM0OiAxMjM0fQpyb290OiBmYWxzZQpydW50aW1lOiBEb2NrZXIKc291cmNlOiB\n"
-                +"zb21lLnJlZ2lzdHJ5LnRsZC9maW5kL2NyYXp5LWFwcGxpY2F0aW9uOjAuMS4wLVNOQVBTSE9UCn\n"
-                +"Rva2VuX3NlcnZpY2VfdXJsOiBodHRwczovL3Rva2VuLnNlcnZpY2UvYWNjZXNzX3Rva2VuCg==";
-        LifecycleEntity lifecycleEntity = applicationLifecycleService.saveInstanceLogLifecycle(
-                instanceId,
-                instanceBootTime,
-                userdataPath, region, userdata, accountId);
+        @Bean
+        ApplicationRepository applicationRepository() {
+            return mock(ApplicationRepository.class);
+        }
 
-        assertThat(lifecycleEntity).isNotNull();
+        @Bean
+        VersionRepository versionRepository() {
+            return mock(VersionRepository.class);
+        }
 
-
+        @Bean
+        LifecycleRepository lifecycleRepository() {
+            return mock(LifecycleRepository.class);
+        }
     }
 }

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/service/impl/ApplicationLifecycleServiceImplTest.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/service/impl/ApplicationLifecycleServiceImplTest.java
@@ -41,11 +41,7 @@ public class ApplicationLifecycleServiceImplTest {
 
     private ApplicationEntity fullstop2;
 
-    private ApplicationEntity yourturn;
-
     private LifecycleEntity runInstance;
-
-    private LifecycleEntity terminteInstance;
 
     private LifecycleEntity stopInstance;
 
@@ -72,7 +68,6 @@ public class ApplicationLifecycleServiceImplTest {
 
         fullstop = new ApplicationEntity("Fullstop");
         fullstop2 = new ApplicationEntity("Fullstop");
-        yourturn = new ApplicationEntity("Yourturn");
 
         runInstance = new LifecycleEntity();
         runInstance.setRegion("eu-west-1");
@@ -80,7 +75,7 @@ public class ApplicationLifecycleServiceImplTest {
         runInstance.setInstanceId("i-1234");
         runInstance.setEventType("RunInstances");
 
-        terminteInstance = new LifecycleEntity();
+        LifecycleEntity terminteInstance = new LifecycleEntity();
         terminteInstance.setEventDate(new DateTime());
         terminteInstance.setEventType("TerminateInstances");
         terminteInstance.setRegion("eu-central-1");
@@ -175,11 +170,10 @@ public class ApplicationLifecycleServiceImplTest {
         String instanceId = "i-1234";
         String region = "eu-west-1";
         String accountId = "123456";
-        String userdata = null;
         LifecycleEntity lifecycleEntity = applicationLifecycleService.saveInstanceLogLifecycle(
                 instanceId,
                 instanceBootTime,
-                userdataPath, region, userdata, accountId);
+                userdataPath, region, null, accountId);
         assertThat(lifecycleEntity).isNull();
 
     }
@@ -202,7 +196,7 @@ public class ApplicationLifecycleServiceImplTest {
                         + "application_version: '0.5-Snaphot'\n"
                         + "environment:\n"
                         + "  xx: xx");
-        LifecycleEntity lifecycleEntity = applicationLifecycleService.saveInstanceLogLifecycle(
+        applicationLifecycleService.saveInstanceLogLifecycle(
                 instanceId,
                 instanceBootTime,
                 userdataPath, region, userdata, accountId);

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/service/impl/SaveApplicationLifecycleRetryTest.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/service/impl/SaveApplicationLifecycleRetryTest.java
@@ -38,7 +38,7 @@ public class SaveApplicationLifecycleRetryTest {
 
     @Before
     public void setUp() throws Exception {
-        // somehow the @RunWith(SpringJUnit4ClassRunner.class) does not wokr well with @EnableRetry annotation
+        // somehow the @RunWith(SpringJUnit4ClassRunner.class) does not work well with @EnableRetry annotation
         // copied this approach to create a Spring context from
         // https://github.com/spring-projects/spring-retry/blob/master/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
         final ApplicationContext context = new AnnotationConfigApplicationContext(TestConfig.class);
@@ -88,7 +88,7 @@ public class SaveApplicationLifecycleRetryTest {
     static class TestConfig {
 
         @Bean
-        ApplicationLifecycleService service() {
+        ApplicationLifecycleService applicationLifecycleService() {
             return new ApplicationLifecycleServiceImpl();
         }
 

--- a/fullstop/src/main/resources/log4j2.xml
+++ b/fullstop/src/main/resources/log4j2.xml
@@ -11,6 +11,7 @@
 
         <Logger name="org.springframework.boot.actuate.audit.listener.AuditListener" level="warn" />
         <Logger name="springfox.documentation" level="warn" />
+        <Logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="OFF" />
 
         <Root level="info">
             <AppenderRef ref="Console"/>


### PR DESCRIPTION
fixes #333 

- disable error log messages from Hibernate
- always start a new transaction for the retriable method (to avoid "broken" hibernate sessions after a PsqlException occurs)
- inject a self reference, to make use of Spring's auto proxies for Retriable and Transactional annotations