### PR TITLE
Add parameter to filter violations by instance ID

### DIFF
--- a/fullstop-api.yaml
+++ b/fullstop-api.yaml
@@ -189,6 +189,13 @@ paths:
           type: array
           items:
             type: string
+        - name: instance_id
+          in: query
+          required: false
+          description: Include only violations from the instance with these ids
+          type: array
+          items:
+            type: string
         - name: from
           in: query
           required: false


### PR DESCRIPTION
Add a parameter to filter violations by instance ID. This would be useful to find violations caused by instances that are currently running in AWS.

Use case: We have many unclosed violations, most referring to instances no longer in existence. We want a way to filter them to look at the ones that come from active instances. Filtering by data is not good enough, because some violations are only checked and reported upon instance creation, and some instances may have been running for a long time. The proposed extra parameter can be used in this situation, for example, by looking for IDs of the currently-running instances in the AWS config frontend.
