### PR TITLE
fix caching

### DIFF
--- a/fullstop-jobs/src/main/java/org/zalando/stups/fullstop/jobs/common/impl/AmiDetailsProviderImpl.java
+++ b/fullstop-jobs/src/main/java/org/zalando/stups/fullstop/jobs/common/impl/AmiDetailsProviderImpl.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.ec2.model.DescribeImagesResult;
 import com.amazonaws.services.ec2.model.Image;
 import com.google.common.collect.ImmutableMap;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.zalando.stups.fullstop.aws.ClientProvider;
 import org.zalando.stups.fullstop.jobs.common.AmiDetailsProvider;
@@ -27,6 +28,7 @@ public class AmiDetailsProviderImpl implements AmiDetailsProvider {
     }
 
     @Override
+    @Cacheable(cacheNames = "ami-details", cacheManager = "oneDayTTLCacheManager")
     public Map<String, String> getAmiDetails(final String accountId, final Region region, final String amiId) {
         final ImmutableMap.Builder<String, String> result = ImmutableMap.builder();
         result.put("ami_id", amiId);

--- a/fullstop-jobs/src/main/java/org/zalando/stups/fullstop/jobs/common/impl/EC2InstanceProviderImpl.java
+++ b/fullstop-jobs/src/main/java/org/zalando/stups/fullstop/jobs/common/impl/EC2InstanceProviderImpl.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.Instance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.zalando.stups.fullstop.aws.ClientProvider;
 import org.zalando.stups.fullstop.jobs.common.EC2InstanceProvider;
@@ -23,6 +24,7 @@ public class EC2InstanceProviderImpl implements EC2InstanceProvider {
     }
 
     @Override
+    @Cacheable(cacheNames = "ec2-instance", cacheManager = "twoHoursTTLCacheManager")
     public Optional<Instance> getById(final String accountId, final Region region, final String instanceId) {
         return clientProvider.getClient(AmazonEC2Client.class, accountId, region)
                 .describeInstances(new DescribeInstancesRequest().withInstanceIds(instanceId))

--- a/fullstop/src/main/java/org/zalando/stups/fullstop/hystrix/HystrixTeamOperations.java
+++ b/fullstop/src/main/java/org/zalando/stups/fullstop/hystrix/HystrixTeamOperations.java
@@ -1,6 +1,7 @@
 package org.zalando.stups.fullstop.hystrix;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.client.HttpClientErrorException;
 import org.zalando.stups.fullstop.teams.Account;
 import org.zalando.stups.fullstop.teams.TeamOperations;
@@ -17,18 +18,21 @@ public class HystrixTeamOperations implements TeamOperations {
     }
 
     @Override
+    @Cacheable(cacheNames = "aws-accounts-by-user", cacheManager = "oneMinuteTTLCacheManager")
     @HystrixCommand(ignoreExceptions = {HttpClientErrorException.class, IllegalArgumentException.class})
     public List<Account> getAwsAccountsByUser(final String userId) {
         return delegate.getAwsAccountsByUser(userId);
     }
 
     @Override
+    @Cacheable(cacheNames = "team-ids-by-user", cacheManager = "oneMinuteTTLCacheManager")
     @HystrixCommand(ignoreExceptions = {HttpClientErrorException.class, IllegalArgumentException.class})
     public Set<String> getTeamIdsByUser(final String userId) {
         return delegate.getTeamIdsByUser(userId);
     }
 
     @Override
+    @Cacheable(cacheNames = "active-aws-accounts", cacheManager = "oneMinuteTTLCacheManager")
     @HystrixCommand(ignoreExceptions = HttpClientErrorException.class)
     public List<Account> getActiveAccounts() {
         return delegate.getActiveAccounts();

--- a/team-service-client-spring/src/main/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperations.java
+++ b/team-service-client-spring/src/main/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperations.java
@@ -2,6 +2,7 @@ package org.zalando.stups.fullstop.teams;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
@@ -40,6 +41,7 @@ public class RestTemplateTeamOperations implements TeamOperations {
     }
 
     @Override
+    @Cacheable(cacheNames = "aws-accounts-by-user", cacheManager = "oneMinuteTTLCacheManager")
     public List<Account> getAwsAccountsByUser(final String userId) {
         Preconditions.checkArgument(StringUtils.hasText(userId), "userId must not be blank");
 
@@ -50,6 +52,7 @@ public class RestTemplateTeamOperations implements TeamOperations {
     }
 
     @Override
+    @Cacheable(cacheNames = "team-ids-by-user", cacheManager = "oneMinuteTTLCacheManager")
     public Set<String> getTeamIdsByUser(final String userId) {
         Preconditions.checkArgument(StringUtils.hasText(userId), "userId must not be blank");
 
@@ -68,6 +71,7 @@ public class RestTemplateTeamOperations implements TeamOperations {
     }
 
     @Override
+    @Cacheable(cacheNames = "active-aws-accounts", cacheManager = "oneMinuteTTLCacheManager")
     public List<Account> getActiveAccounts() {
         final ResponseEntity<List<Account>> response = restOperations.exchange(
                 get(URI.create(baseUrl + "/api/accounts/aws")).build(), accountType);


### PR DESCRIPTION
some caches are not considered, because annotations on interface level are processed, iff "interface-proxies" are created. However this does not work for CGLIB proxies (proxyTargetClass=true).
My stupid quick fix is, to duplicate the annotations, to have them on both, the interface and the class level. Then either case should succeed.