### PR TITLE
Case insensitive scm urls

### DIFF
--- a/fullstop-plugins/fullstop-scm-repository-plugin/src/main/java/org/zalando/stups/fullstop/plugin/scm/Repositories.java
+++ b/fullstop-plugins/fullstop-scm-repository-plugin/src/main/java/org/zalando/stups/fullstop/plugin/scm/Repositories.java
@@ -2,6 +2,7 @@ package org.zalando.stups.fullstop.plugin.scm;
 
 import org.zalando.stups.fullstop.plugin.scm.config.ScmRepositoryPluginProperties;
 
+import javax.annotation.Nonnull;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -20,8 +21,9 @@ public class Repositories {
         pattern = Pattern.compile(format(GITHUB_REGEX_TEMPLATE, hostsPattern));
     }
 
-    Repository parse(String url) throws UnknownScmUrlException {
-        final Matcher matcher = pattern.matcher(url);
+    Repository parse(@Nonnull String url) throws UnknownScmUrlException {
+        final String lowerCaseUrl = url.toLowerCase();
+        final Matcher matcher = pattern.matcher(lowerCaseUrl);
         if (matcher.matches()) {
             return new Repository(
                     matcher.group("host"),

--- a/fullstop-plugins/fullstop-scm-repository-plugin/src/main/java/org/zalando/stups/fullstop/plugin/scm/ScmRepositoryPlugin.java
+++ b/fullstop-plugins/fullstop-scm-repository-plugin/src/main/java/org/zalando/stups/fullstop/plugin/scm/ScmRepositoryPlugin.java
@@ -83,6 +83,7 @@ public class ScmRepositoryPlugin extends AbstractEC2InstancePlugin {
                             .withType(ILLEGAL_SCM_REPOSITORY)
                             .withMetaInfo(ImmutableMap.of(
                                     "application_id", context.getApplicationId().orElse(""),
+                                    "deployment_artifact", context.getSource().orElse(""),
                                     "error_message", e.getMessage()))
                             .build()
             );
@@ -103,6 +104,7 @@ public class ScmRepositoryPlugin extends AbstractEC2InstancePlugin {
                             .withType(ILLEGAL_SCM_REPOSITORY)
                             .withMetaInfo(ImmutableMap.of(
                                     "application_id", context.getApplicationId().orElse(""),
+                                    "deployment_artifact", context.getSource().orElse(""),
                                     "normalized_scm_source_url", scmSourceRepository.toString(),
                                     "allowed_owners", allowedOwnerPattern,
                                     "actual_owner", scmSourceRepository.getOwner()))
@@ -137,6 +139,7 @@ public class ScmRepositoryPlugin extends AbstractEC2InstancePlugin {
                                 .withType(SCM_URL_NOT_MATCH_WITH_KIO)
                                 .withMetaInfo(ImmutableMap.of(
                                         "application_id", app.getId(),
+                                        "deployment_artifact", context.getSource().orElse(""),
                                         "normalized_scm_source_url", scmSourceRepository.toString(),
                                         "normalized_kio_scm_url", kioRepository.toString())).build());
             }
@@ -147,6 +150,7 @@ public class ScmRepositoryPlugin extends AbstractEC2InstancePlugin {
                             .withType(SCM_URL_NOT_MATCH_WITH_KIO)
                             .withMetaInfo(ImmutableMap.of(
                                     "application_id", app.getId(),
+                                    "deployment_artifact", context.getSource().orElse(""),
                                     "normalized_scm_source_url", scmSourceRepository.toString(),
                                     "kio_scm_url", kioScmUrl,
                                     "error_message", e.getMessage())).build());

--- a/fullstop-plugins/fullstop-scm-repository-plugin/src/main/java/org/zalando/stups/fullstop/plugin/scm/UnknownScmUrlException.java
+++ b/fullstop-plugins/fullstop-scm-repository-plugin/src/main/java/org/zalando/stups/fullstop/plugin/scm/UnknownScmUrlException.java
@@ -5,6 +5,6 @@ import static java.lang.String.format;
 class UnknownScmUrlException extends Exception {
 
     UnknownScmUrlException(String url) {
-        super(format("%s does not look like a valid git repository", url));
+        super(format("'%s' does not look like a valid git repository", url));
     }
 }

--- a/fullstop-plugins/fullstop-scm-repository-plugin/src/test/java/org/zalando/stups/fullstop/plugin/scm/RepositoriesTest.java
+++ b/fullstop-plugins/fullstop-scm-repository-plugin/src/test/java/org/zalando/stups/fullstop/plugin/scm/RepositoriesTest.java
@@ -55,6 +55,7 @@ public class RepositoriesTest {
         return asList(
                 new Object[][]{
                         {singletonMap("github.com", "^.+$"), "https://github.com/zalando-stups/fullstop", new Repository("github.com", "zalando-stups", "fullstop")},
+                        {singletonMap("github.com", "^.+$"), "https://GitHub.com/zAlAnDo-STUPS/FULLstop", new Repository("github.com", "zalando-stups", "fullstop")},
                         {singletonMap("github.com", "^.+$"), "https://github.com:443/zalando-stups/fullstop", new Repository("github.com", "zalando-stups", "fullstop")},
                         {singletonMap("github.com", "^.+$"), "git:https://github.com/zalando-stups/fullstop", new Repository("github.com", "zalando-stups", "fullstop")},
                         {singletonMap("github.com", "^.+$"), "http://github.com/zalando-stups/fullstop", new Repository("github.com", "zalando-stups", "fullstop")},

--- a/fullstop-plugins/fullstop-scm-repository-plugin/src/test/java/org/zalando/stups/fullstop/plugin/scm/ScmRepositoryPluginTest.java
+++ b/fullstop-plugins/fullstop-scm-repository-plugin/src/test/java/org/zalando/stups/fullstop/plugin/scm/ScmRepositoryPluginTest.java
@@ -66,6 +66,7 @@ public class ScmRepositoryPluginTest {
 
         when(mockContext.violation()).thenReturn(new ViolationBuilder());
         when(mockContext.getApplicationId()).thenReturn(Optional.of("fullstop"));
+        when(mockContext.getSource()).thenReturn(Optional.of("zalando-stups/fullstop:v1"));
     }
 
     @After
@@ -112,7 +113,6 @@ public class ScmRepositoryPluginTest {
     @Test
     public void testProcessBlankScmSourceUrl() throws Exception {
         when(mockContext.getScmSource()).thenReturn(Optional.of(ImmutableMap.of("url", " ", "user", "unittester", "revision", "1a2b3c4d")));
-        when(mockContext.getSource()).thenReturn(empty());
 
         plugin.process(mockContext);
 
@@ -132,6 +132,7 @@ public class ScmRepositoryPluginTest {
         plugin.process(mockContext);
 
         verify(mockContext).getScmSource();
+        verify(mockContext).getSource();
         verify(mockContext).getApplicationId();
         verify(mockContext).violation();
         verify(mockRepositories).parse(eq(badScmUrl));
@@ -151,6 +152,7 @@ public class ScmRepositoryPluginTest {
         verify(mockContext).getApplicationId();
         verify(mockContext).violation();
         verify(mockContext).getKioApplication();
+        verify(mockContext).getSource();
         verify(mockRepositories).parse(eq(unallowedRepo.toString()));
         verify(mockViolationSink).put(argThat(hasType(ILLEGAL_SCM_REPOSITORY)));
     }
@@ -196,6 +198,7 @@ public class ScmRepositoryPluginTest {
 
         verify(mockContext).getKioApplication();
         verify(mockContext).getScmSource();
+        verify(mockContext).getSource();
         verify(mockRepositories).parse(eq(validRepo.toString()));
         verify(mockRepositories).parse(eq(kioApp.getScmUrl()));
         verify(mockContext).violation();
@@ -213,6 +216,7 @@ public class ScmRepositoryPluginTest {
 
         verify(mockContext).getKioApplication();
         verify(mockContext).getScmSource();
+        verify(mockContext).getSource();
         verify(mockRepositories).parse(eq(validRepo.toString()));
         verify(mockRepositories).parse(eq(kioApp.getScmUrl()));
         verify(mockContext).violation();


### PR DESCRIPTION
* SCM urls are converted to lower case before we try to parse them
* minor improvements to violation meta data:
    * add "deployment_artifact" to the relevant violation types
    * improved message on unparseable urls