### PR TITLE
CachingClientProvider: shutdown the expired clients

### DIFF
--- a/fullstop-aws-support/fullstop-aws-client-support/src/main/java/org/zalando/stups/fullstop/aws/CachingClientProvider.java
+++ b/fullstop-aws-support/fullstop-aws-client-support/src/main/java/org/zalando/stups/fullstop/aws/CachingClientProvider.java
@@ -48,7 +48,7 @@ public class CachingClientProvider implements ClientProvider {
         // this parameters have to be configurable
         cache = CacheBuilder.newBuilder()
                 .maximumSize(500)
-                .expireAfterWrite(50, TimeUnit.MINUTES)
+                .expireAfterAccess(50, TimeUnit.MINUTES)
                 .removalListener((RemovalNotification<Key<?>, AmazonWebServiceClient> notification) -> {
                     logger.debug("Shutting down expired client for key: {}", notification.getKey());
                     notification.getValue().shutdown();

--- a/fullstop-aws-support/fullstop-aws-client-support/src/main/java/org/zalando/stups/fullstop/aws/CachingClientProvider.java
+++ b/fullstop-aws-support/fullstop-aws-client-support/src/main/java/org/zalando/stups/fullstop/aws/CachingClientProvider.java
@@ -5,9 +5,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.regions.Region;
 import com.google.common.base.MoreObjects;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.google.common.cache.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -21,6 +19,8 @@ import java.util.concurrent.TimeUnit;
  */
 @Service
 public class CachingClientProvider implements ClientProvider {
+
+    private final Logger logger = LoggerFactory.getLogger(CacheLoader.class);
 
     private static final String ROLE_SESSION_NAME = "fullstop";
 
@@ -44,13 +44,15 @@ public class CachingClientProvider implements ClientProvider {
 
     @PostConstruct
     public void init() {
-
         // TODO
         // this parameters have to be configurable
-        cache = CacheBuilder.newBuilder().maximumSize(500).expireAfterWrite(50, TimeUnit.MINUTES).build(
-                new CacheLoader<Key<?>, AmazonWebServiceClient>() {
-                    private final Logger logger = LoggerFactory.getLogger(CacheLoader.class);
-
+        cache = CacheBuilder.newBuilder()
+                .maximumSize(500)
+                .expireAfterWrite(50, TimeUnit.MINUTES)
+                .removalListener((RemovalNotification<Key<?>, AmazonWebServiceClient> notification) -> {
+                    logger.debug("Shutting down expired client for key: {}", notification.getKey());
+                    notification.getValue().shutdown();
+                }).build(new CacheLoader<Key<?>, AmazonWebServiceClient>() {
                     @Override
                     public AmazonWebServiceClient load(@Nonnull final Key<?> key) throws Exception {
                         logger.debug("CacheLoader active for Key : {}", key);
@@ -59,7 +61,7 @@ public class CachingClientProvider implements ClientProvider {
                                 new STSAssumeRoleSessionCredentialsProvider(
                                         buildRoleArn(key.accountId),
                                         ROLE_SESSION_NAME),
-                                        new ClientConfiguration().withMaxErrorRetry(MAX_ERROR_RETRY));
+                                new ClientConfiguration().withMaxErrorRetry(MAX_ERROR_RETRY));
                     }
                 });
     }


### PR DESCRIPTION
AWS client instances reference a ton of resources (HTTP connection managers, idle termination threads, etc), so even though releasing them explicitly isn't mandatory, it could free up a lot of resources. Modify the caching code to explicitly shutdown the instances when they get cleaned up.