### PR TITLE
increase SQS visibility timeout

### DIFF
--- a/fullstop/src/main/resources/config/application.yml
+++ b/fullstop/src/main/resources/config/application.yml
@@ -59,7 +59,7 @@ fullstop:
 
             # A period of time during which Amazon SQS prevents other consuming components
             # from receiving and processing that message
-            visibilityTimeout: 60
+            visibilityTimeout: 300
 
             # The S3 end point specific to a region
             s3Region: ${FULLSTOP_S3_REGION}


### PR DESCRIPTION
The default timeout of one minute is not sufficient to process large events. Sometimes we run into rate limits, which are handled by sleeping with exponential backoff.