### PR TITLE
handle redirect correctly

### DIFF
--- a/fullstop-jobs/src/main/java/org/zalando/stups/fullstop/jobs/common/HttpGetRootCall.java
+++ b/fullstop-jobs/src/main/java/org/zalando/stups/fullstop/jobs/common/HttpGetRootCall.java
@@ -54,7 +54,7 @@ public class HttpGetRootCall implements Callable<HttpCallResult> {
             final int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 401 || statusCode == 403) {
                 log.debug("URI {} is secured GET / returned {}", uri, statusCode);
-            } else if (String.valueOf(statusCode).startsWith("3")) {
+            } else if (String.valueOf(statusCode).startsWith("3") && scheme.equals("http")) {
                 if (location.startsWith("https")) {
                     log.debug("URI {} redirects to an https location: {}", uri, location);
                 } else {


### PR DESCRIPTION
A redirect is only valid in case of http -> https. When called with https,
 a service should respond with 401. (Except publicly accessible applications)