### PR TITLE
fix UNSECURED_ROOT_USER logic

### DIFF
--- a/fullstop-jobs/src/main/java/org/zalando/stups/fullstop/jobs/iam/NoPasswordsJob.java
+++ b/fullstop-jobs/src/main/java/org/zalando/stups/fullstop/jobs/iam/NoPasswordsJob.java
@@ -84,7 +84,7 @@ public class NoPasswordsJob implements FullstopJob {
                 Stream.of(csvReportEntries)
                         .flatMap(Collection::stream)
                         .filter(c -> c.getUser().equals(ROOT_ACCOUNT) || c.getUser().endsWith(ROOT_SUFFIX))
-                        .filter(c -> !c.isMfaActive() || c.isAccessKey1Active() || c.isAccessKey2Active())
+                        .filter(c -> (c.isPasswordEnabled() && !c.isMfaActive()) || c.isAccessKey1Active() || c.isAccessKey2Active())
                         .forEach(c -> {
                             final Map<String, String> metaInfo = new HashMap<>();
                             metaInfo.put("account_id", accountId);


### PR DESCRIPTION
The check verifies if MFA is enabled for root users. However this is only
necessary when there is actually a password set.
With the new Organizations API there is no need for a password and hence there is no need to enable MFA