### PR TITLE
by default don't restrict violations by time

### DIFF
--- a/fullstop-web/fullstop-violations-rest/src/main/java/org/zalando/stups/fullstop/web/controller/ViolationsController.java
+++ b/fullstop-web/fullstop-violations-rest/src/main/java/org/zalando/stups/fullstop/web/controller/ViolationsController.java
@@ -128,7 +128,7 @@ public class ViolationsController {
             @PageableDefault(page = 0, size = 10, sort = "id", direction = ASC) final Pageable pageable) throws NotFoundException {
 
         if (from == null) {
-            from = DateTime.now().minusWeeks(1);
+            from = new DateTime(0);
         }
 
         if (to == null) {


### PR DESCRIPTION
if no `from` param is given, include all violations in the response,
not only ones from the last week.