### PR TITLE
fix aws account access control

### DIFF
--- a/fullstop-job-launcher/src/main/java/org/zalando/stups/fullstop/config/ClientConfig.java
+++ b/fullstop-job-launcher/src/main/java/org/zalando/stups/fullstop/config/ClientConfig.java
@@ -2,6 +2,7 @@ package org.zalando.stups.fullstop.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -10,21 +11,35 @@ import org.zalando.stups.clients.kio.spring.KioClientResponseErrorHandler;
 import org.zalando.stups.clients.kio.spring.RestTemplateKioOperations;
 import org.zalando.stups.fullstop.teams.RestTemplateTeamOperations;
 import org.zalando.stups.fullstop.teams.TeamOperations;
+import org.zalando.stups.fullstop.teams.TeamServiceProperties;
 import org.zalando.stups.oauth2.spring.client.StupsOAuth2RestTemplate;
 import org.zalando.stups.oauth2.spring.client.StupsTokensAccessTokenProvider;
 import org.zalando.stups.tokens.AccessTokens;
 
 @Configuration
+@EnableConfigurationProperties(TeamServiceProperties.class)
 public class ClientConfig {
 
+    private final AccessTokens accessTokens;
+
+    private final TeamServiceProperties teamServiceProperties;
+
+    private final String kioBaseUrl;
+
+    private final String teamServiceBaseUrl;
+
+
     @Autowired
-    private AccessTokens accessTokens;
-
-    @Value("${fullstop.clients.kio.url}")
-    private String kioBaseUrl;
-
-    @Value("${fullstop.clients.teamService.url}")
-    private String teamServiceBaseUrl;
+    public ClientConfig(
+            AccessTokens accessTokens,
+            TeamServiceProperties teamServiceProperties,
+            @Value("${fullstop.clients.kio.url}") String kioBaseUrl,
+            @Value("${fullstop.clients.teamService.url}") String teamServiceBaseUrl) {
+        this.accessTokens = accessTokens;
+        this.teamServiceProperties = teamServiceProperties;
+        this.kioBaseUrl = kioBaseUrl;
+        this.teamServiceBaseUrl = teamServiceBaseUrl;
+    }
 
     @Bean
     KioOperations kioOperations() {
@@ -43,7 +58,7 @@ public class ClientConfig {
     public TeamOperations teamOperations() {
         return new RestTemplateTeamOperations(
                 new StupsOAuth2RestTemplate(new StupsTokensAccessTokenProvider("teamService", accessTokens)),
-                teamServiceBaseUrl);
+                teamServiceBaseUrl, teamServiceProperties);
     }
 
 

--- a/fullstop/src/main/java/org/zalando/stups/fullstop/config/ClientConfig.java
+++ b/fullstop/src/main/java/org/zalando/stups/fullstop/config/ClientConfig.java
@@ -2,6 +2,7 @@ package org.zalando.stups.fullstop.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -15,6 +16,7 @@ import org.zalando.stups.fullstop.hystrix.HystrixKioOperations;
 import org.zalando.stups.fullstop.hystrix.HystrixTeamOperations;
 import org.zalando.stups.fullstop.teams.RestTemplateTeamOperations;
 import org.zalando.stups.fullstop.teams.TeamOperations;
+import org.zalando.stups.fullstop.teams.TeamServiceProperties;
 import org.zalando.stups.oauth2.spring.client.StupsOAuth2RestTemplate;
 import org.zalando.stups.oauth2.spring.client.StupsTokensAccessTokenProvider;
 import org.zalando.stups.pierone.client.HystrixSpringPieroneOperations;
@@ -30,19 +32,32 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toMap;
 
 @Configuration
+@EnableConfigurationProperties(TeamServiceProperties.class)
 public class ClientConfig {
 
+    private final AccessTokens accessTokens;
+
+    private final TeamServiceProperties teamServiceProperties;
+
+    private final String kioBaseUrl;
+
+    private final String teamServiceBaseUrl;
+
+    private final String pieroneUrls;
+
     @Autowired
-    private AccessTokens accessTokens;
-
-    @Value("${fullstop.clients.kio.url}")
-    private String kioBaseUrl;
-
-    @Value("${fullstop.clients.teamService.url}")
-    private String teamServiceBaseUrl;
-
-    @Value("${fullstop.clients.pierone.urls}")
-    private String pieroneUrls;
+    public ClientConfig(
+            AccessTokens accessTokens,
+            TeamServiceProperties teamServiceProperties,
+            @Value("${fullstop.clients.kio.url}") String kioBaseUrl,
+            @Value("${fullstop.clients.teamService.url}") String teamServiceBaseUrl,
+            @Value("${fullstop.clients.pierone.urls}") String pieroneUrls) {
+        this.accessTokens = accessTokens;
+        this.teamServiceProperties = teamServiceProperties;
+        this.kioBaseUrl = kioBaseUrl;
+        this.teamServiceBaseUrl = teamServiceBaseUrl;
+        this.pieroneUrls = pieroneUrls;
+    }
 
     @Bean
     public KioOperations kioOperations() {
@@ -57,7 +72,7 @@ public class ClientConfig {
         return new HystrixTeamOperations(
                 new RestTemplateTeamOperations(
                         buildOAuth2RestTemplate("teamService"),
-                        teamServiceBaseUrl));
+                        teamServiceBaseUrl, teamServiceProperties));
     }
 
     @Bean

--- a/team-service-client-spring/pom.xml
+++ b/team-service-client-spring/pom.xml
@@ -36,6 +36,27 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/team-service-client-spring/pom.xml
+++ b/team-service-client-spring/pom.xml
@@ -48,6 +48,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/team-service-client-spring/pom.xml
+++ b/team-service-client-spring/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/team-service-client-spring/src/main/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperations.java
+++ b/team-service-client-spring/src/main/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperations.java
@@ -2,10 +2,12 @@ package org.zalando.stups.fullstop.teams;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Streams;
+import com.google.common.collect.ImmutableMap;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestOperations;
 
@@ -13,7 +15,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -37,27 +39,27 @@ public class RestTemplateTeamOperations implements TeamOperations {
 
     private final String baseUrl;
 
-    public RestTemplateTeamOperations(final RestOperations restOperations, final String baseUrl) {
+    private final TeamServiceProperties teamServiceProperties;
+
+    public RestTemplateTeamOperations(final RestOperations restOperations,
+                                      final String baseUrl,
+                                      final TeamServiceProperties teamServiceProperties) {
         this.restOperations = restOperations;
         this.baseUrl = baseUrl;
+        this.teamServiceProperties = teamServiceProperties;
     }
 
     @Override
     @Cacheable(cacheNames = "aws-accounts-by-user", cacheManager = "oneMinuteTTLCacheManager")
     public List<Account> getAwsAccountsByUser(final String userId) {
-        Preconditions.checkArgument(StringUtils.hasText(userId), "userId must not be blank");
-
-        final ResponseEntity<List<Account>> typeAws = restOperations.exchange(
-                get(URI.create(baseUrl + "/api/accounts/aws?member=" + userId)).build(), userTeamListType);
-        Preconditions.checkState(typeAws.getStatusCode().is2xxSuccessful(),
-                "getAwsAccountsByUser for type AWS failed: %s", typeAws);
-        final ResponseEntity<List<Account>> typeK8s = restOperations.exchange(
-                get(URI.create(baseUrl + "/api/accounts/kubernetes?role=PowerUser&member=" + userId)).build(),
-                userTeamListType);
-        Preconditions.checkState(typeK8s.getStatusCode().is2xxSuccessful(),
-                "getAwsAccountsByUser for type Kubernetes failed: %s", typeK8s);
-        return Streams.concat(typeAws.getBody().stream(), typeK8s.getBody().stream())
-                .collect(Collectors.toList());
+        Assert.hasText(userId, "userId must not be blank");
+        final String url = baseUrl + "/api/accounts/aws?member={member}&role={role}";
+        return Stream.of(teamServiceProperties.getAwsMembershipRolesAsArray())
+                .map(role -> ImmutableMap.of("role", role, "member", userId))
+                .map(queryParams -> restOperations.exchange(url, HttpMethod.GET, null, userTeamListType, queryParams))
+                .flatMap(response -> response.getBody().stream())
+                .distinct()
+                .collect(toList());
     }
 
     @Override

--- a/team-service-client-spring/src/main/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperations.java
+++ b/team-service-client-spring/src/main/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperations.java
@@ -54,7 +54,9 @@ public class RestTemplateTeamOperations implements TeamOperations {
     public List<Account> getAwsAccountsByUser(final String userId) {
         Assert.hasText(userId, "userId must not be blank");
         final String url = baseUrl + "/api/accounts/aws?member={member}&role={role}";
+
         return Stream.of(teamServiceProperties.getAwsMembershipRolesAsArray())
+                .parallel()
                 .map(role -> ImmutableMap.of("role", role, "member", userId))
                 .map(queryParams -> restOperations.exchange(url, HttpMethod.GET, null, userTeamListType, queryParams))
                 .flatMap(response -> response.getBody().stream())

--- a/team-service-client-spring/src/main/java/org/zalando/stups/fullstop/teams/TeamServiceProperties.java
+++ b/team-service-client-spring/src/main/java/org/zalando/stups/fullstop/teams/TeamServiceProperties.java
@@ -1,0 +1,25 @@
+package org.zalando.stups.fullstop.teams;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("fullstop.clients.teamService")
+public class TeamServiceProperties {
+
+    /**
+     * Comma-separated list of roles, that can be queried to verify if a user has access to some AWS account and is
+     * authorized to resolve violations.
+     */
+    private String awsMembershipRoles = "PowerUser,Deployer";
+
+    public String getAwsMembershipRoles() {
+        return awsMembershipRoles;
+    }
+
+    public void setAwsMembershipRoles(String awsMembershipRoles) {
+        this.awsMembershipRoles = awsMembershipRoles;
+    }
+
+    public String[] getAwsMembershipRolesAsArray() {
+        return awsMembershipRoles.split(",");
+    }
+}

--- a/team-service-client-spring/src/test/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperationsTest.java
+++ b/team-service-client-spring/src/test/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperationsTest.java
@@ -75,7 +75,7 @@ public class RestTemplateTeamOperationsTest {
 
         @Bean
         MockRestServiceServer mockServer(RestTemplate restTemplate) {
-            return MockRestServiceServer.bindTo(restTemplate).build();
+            return MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
         }
 
         @Bean

--- a/team-service-client-spring/src/test/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperationsTest.java
+++ b/team-service-client-spring/src/test/java/org/zalando/stups/fullstop/teams/RestTemplateTeamOperationsTest.java
@@ -1,0 +1,58 @@
+package org.zalando.stups.fullstop.teams;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+public class RestTemplateTeamOperationsTest {
+
+    private MockRestServiceServer mockServer;
+    private TeamServiceProperties properties;
+    private RestTemplateTeamOperations teamOperations;
+
+    @Before
+    public void setUp() throws Exception {
+        final RestTemplate restTemplate = new RestTemplate();
+        mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+        properties = new TeamServiceProperties();
+        teamOperations = new RestTemplateTeamOperations(restTemplate, "http://test.local", properties);
+    }
+
+    @Test
+    public void getAwsAccountsByUser() throws Exception {
+        properties.setAwsMembershipRoles("PowerUser,MasterOfDisaster");
+        final String uid = "mickeymouse";
+
+        mockAccountsRequest(uid, "PowerUser", "power-user-accounts.json");
+        mockAccountsRequest(uid, "MasterOfDisaster", "master-of-disaster-accounts.json");
+
+        final List<Account> accounts = teamOperations.getAwsAccountsByUser(uid);
+
+        assertThat(accounts).containsOnly(
+                new Account("111222333444", "firstaccount", "aws", "", "dagobert", false),
+                new Account("555666777888", "secondaccount", "aws", "", "dagobert", false),
+                new Account("999000111222", "thirdaccount", "aws", "", "ticktricktrack", true)
+        );
+        mockServer.verify();
+    }
+
+    private void mockAccountsRequest(String uid, String role, String responseBodyFile) {
+        mockServer.expect(method(GET)).andExpect(requestTo(startsWith("http://test.local/api/accounts/aws?")))
+                .andExpect(queryParam("member", uid)).andExpect(queryParam("role", role))
+                .andRespond(withSuccess(new ClassPathResource(responseBodyFile), APPLICATION_JSON));
+    }
+
+}

--- a/team-service-client-spring/src/test/resources/application.yaml
+++ b/team-service-client-spring/src/test/resources/application.yaml
@@ -1,0 +1,4 @@
+fullstop:
+  clients:
+    teamService:
+      awsMembershipRoles: "PowerUser,MasterOfDisaster"

--- a/team-service-client-spring/src/test/resources/master-of-disaster-accounts.json
+++ b/team-service-client-spring/src/test/resources/master-of-disaster-accounts.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "111222333444",
+    "name": "firstaccount",
+    "provider": "aws",
+    "type": "aws",
+    "description": "",
+    "members": [
+      {
+        "id": "mickeymouse",
+        "account_id": "mickeymouse"
+      },
+      {
+        "id": "donaldduck",
+        "account_id": "donaldduck"
+      }
+    ],
+    "owner": "dagobert",
+    "disabled": false
+  },
+  {
+    "id": "999000111222",
+    "name": "thirdaccount",
+    "provider": "aws",
+    "type": "aws",
+    "description": "",
+    "members": [],
+    "owner": "ticktricktrack",
+    "disabled": true
+  }
+]

--- a/team-service-client-spring/src/test/resources/power-user-accounts.json
+++ b/team-service-client-spring/src/test/resources/power-user-accounts.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "111222333444",
+    "name": "firstaccount",
+    "provider": "aws",
+    "type": "aws",
+    "description": "",
+    "members": [
+      {
+        "id": "mickeymouse",
+        "account_id": "mickeymouse"
+      },
+      {
+        "id": "donaldduck",
+        "account_id": "donaldduck"
+      }
+    ],
+    "owner": "dagobert",
+    "disabled": false
+  },
+  {
+    "id": "555666777888",
+    "name": "secondaccount",
+    "provider": "aws",
+    "type": "aws",
+    "description": "",
+    "members": [
+      {
+        "id": "mickeymouse",
+        "account_id": "mickeymouse"
+      },
+      {
+        "id": "goofy",
+        "account_id": "goofy"
+      }
+    ],
+    "owner": "dagobert",
+    "disabled": false
+  }
+]


### PR DESCRIPTION
Fix AWS account membership logic:

* query for a configurable list of roles (by default `Deployer` and `PowerUser`)