### PR TITLE
fixed CrossAccountPolicyForIAMJob

### DIFF
--- a/fullstop-jobs/pom.xml
+++ b/fullstop-jobs/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.zalando.stups</groupId>
         <artifactId>fullstop-parent</artifactId>
         <version>18</version>
-        <relativePath />
+        <relativePath/>
     </parent>
     <artifactId>fullstop-jobs</artifactId>
     <name>Fullstop -- Jobs</name>
@@ -44,10 +45,10 @@
             <version>${fullstop-aws-client-support.version}</version>
         </dependency>
         <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>fullstop-aws-userdata-support</artifactId>
-        <version>${fullstop-aws-userdata-support.version}</version>
-    </dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fullstop-aws-userdata-support</artifactId>
+            <version>${fullstop-aws-userdata-support.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -120,6 +121,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.zalando.stups</groupId>
+            <artifactId>fullstop-test-support</artifactId>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/fullstop-jobs/src/test/java/org/zalando/stups/fullstop/jobs/policy/CrossAccountPolicyForIAMJobTest.java
+++ b/fullstop-jobs/src/test/java/org/zalando/stups/fullstop/jobs/policy/CrossAccountPolicyForIAMJobTest.java
@@ -13,22 +13,28 @@ import org.zalando.stups.fullstop.jobs.common.AccountIdSupplier;
 import org.zalando.stups.fullstop.jobs.common.AwsApplications;
 import org.zalando.stups.fullstop.jobs.config.JobsProperties;
 import org.zalando.stups.fullstop.jobs.exception.JobExceptionHandler;
+import org.zalando.stups.fullstop.violation.ViolationMatchers;
 import org.zalando.stups.fullstop.violation.ViolationSink;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.mockito.Mockito.*;
+import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.zalando.stups.fullstop.violation.ViolationType.CROSS_ACCOUNT_ROLE;
 
 public class CrossAccountPolicyForIAMJobTest {
 
-    public static final String ACCOUNT_ID = "11111111";
-    public static final String REGION1 = "eu-west-1";
-    public static final String ROLE_ID = "fdsakufsdu";
-    public static final String ARN = "arn:dsfasd";
-    public static final String ARN_2 = "arn:oiu1237";
-    public static final String MANAGEMENT_ACCOUNT = "5555555555";
+    private static final String ACCOUNT_ID = "111222333444";
+    private static final String MANAGEMENT_ACCOUNT = "999888777666";
 
-    public static final String INVALID_POLICY_DOCUMENT = "{\n" +
+    private static final String AWS_SERVICE_POLICY_DOCUMENT = "{\n" +
             "    \"Version\": \"2008-10-17\",\n" +
             "    \"Statement\": [\n" +
             "        {\n" +
@@ -42,7 +48,7 @@ public class CrossAccountPolicyForIAMJobTest {
             "    ]\n" +
             "}";
 
-    public static final String VALID_POLICY_DOCUMENT = "{\n" +
+    private static final String CROSS_ACCOUNT_POLICY_DOCUMENT = "{\n" +
             "    \"Version\": \"2012-10-17\",\n" +
             "    \"Statement\": [\n" +
             "        {\n" +
@@ -55,7 +61,51 @@ public class CrossAccountPolicyForIAMJobTest {
             "        }\n" +
             "    ]\n" +
             "}";
-    public static final String ROLE_NAME = "name";
+
+    private static final String MANAGEMENT_POLICY_DOCUMENT = "{\n" +
+            "    \"Version\": \"2012-10-17\",\n" +
+            "    \"Statement\": [\n" +
+            "        {\n" +
+            "            \"Sid\": \"\",\n" +
+            "            \"Effect\": \"Allow\",\n" +
+            "            \"Principal\": {\n" +
+            "                \"AWS\": \"arn:aws:iam::" + MANAGEMENT_ACCOUNT + ":root\"\n" +
+            "            },\n" +
+            "            \"Action\": \"sts:AssumeRole\"\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}";
+
+    private static final String SAME_ACCOUNT_POLICY_DOCUMENT = "{\n" +
+            "    \"Version\": \"2012-10-17\",\n" +
+            "    \"Statement\": [\n" +
+            "        {\n" +
+            "            \"Sid\": \"\",\n" +
+            "            \"Effect\": \"Allow\",\n" +
+            "            \"Principal\": {\n" +
+            "                \"AWS\": \"arn:aws:iam::" + ACCOUNT_ID + ":root\"\n" +
+            "            },\n" +
+            "            \"Action\": \"sts:AssumeRole\"\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}";
+
+    /**
+     * When referencing a role that has been deleted, AWS won't show its ARN, but only the internal GUID.
+     */
+    private static final String DELETED_ROLE_POLICY_DOCUMENT = "{\n" +
+            "    \"Version\": \"2012-10-17\",\n" +
+            "    \"Statement\": [\n" +
+            "        {\n" +
+            "            \"Sid\": \"\",\n" +
+            "            \"Effect\": \"Allow\",\n" +
+            "            \"Principal\": {\n" +
+            "                \"AWS\": \"AROAIM3TRURL24R6YZAS5\"\n" +
+            "            },\n" +
+            "            \"Action\": \"sts:AssumeRole\"\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}";
 
     private ViolationSink violationSinkMock;
 
@@ -80,22 +130,23 @@ public class CrossAccountPolicyForIAMJobTest {
         this.mockAmazonIdentityManagementClient = mock(AmazonIdentityManagementClient.class);
         this.mockAwsApplications = mock(AwsApplications.class);
 
-        final Role role = new Role();
-        role.setArn(ARN);
-        role.setRoleName(ROLE_NAME);
-        role.setRoleId(ROLE_ID);
-        role.setAssumeRolePolicyDocument(INVALID_POLICY_DOCUMENT);
-
-        final Role role1 = new Role();
-        role1.setArn(ARN_2);
-        role1.setRoleName(ROLE_NAME);
-        role1.setRoleId(ROLE_ID);
-        role1.setAssumeRolePolicyDocument(VALID_POLICY_DOCUMENT);
-
         mockListRolesResult = new ListRolesResult();
-        mockListRolesResult.setRoles(newArrayList(role, role1));
+        mockListRolesResult.setRoles(asList(
+                createRole("aws-service-role", AWS_SERVICE_POLICY_DOCUMENT),
+                createRole("cross-account-role", CROSS_ACCOUNT_POLICY_DOCUMENT),
+                createRole("same-account-role", SAME_ACCOUNT_POLICY_DOCUMENT),
+                createRole("deleted-role-reference-role", DELETED_ROLE_POLICY_DOCUMENT),
+                createRole("management-account-role", MANAGEMENT_POLICY_DOCUMENT)));
 
         when(clientProviderMock.getClient(any(), any(String.class), any(Region.class))).thenReturn(mockAmazonIdentityManagementClient);
+    }
+
+    private Role createRole(String name, String policyDocument) {
+        return new Role()
+                .withArn("arn:aws:iam::" + ACCOUNT_ID + ":role/" + name)
+                .withRoleName(name)
+                .withRoleId(randomAlphanumeric(21).toUpperCase()) // IDs look like: "AROAIM3TRURL24R6YZAS5"
+                .withAssumeRolePolicyDocument(policyDocument);
     }
 
     @After
@@ -127,7 +178,7 @@ public class CrossAccountPolicyForIAMJobTest {
         verify(accountIdSupplierMock).get();
         verify(clientProviderMock).getClient(any(), any(String.class), any(Region.class));
         verify(mockAmazonIdentityManagementClient).listRoles(any(ListRolesRequest.class));
-        verify(jobsPropertiesMock,times(1)).getManagementAccount();
-        verify(violationSinkMock).put(any());
+        verify(jobsPropertiesMock, atLeastOnce()).getManagementAccount();
+        verify(violationSinkMock, times(1)).put(argThat(ViolationMatchers.hasType(CROSS_ACCOUNT_ROLE)));
     }
 }


### PR DESCRIPTION
When a role that has been deleted is referenced somewhere, AWS won't
show its ARN, but only the internal GUID, which looks like
`AROAIM3TRURL24R6YZAS5`.
Those GUID were incorrectly detected as cross-account roles.

This change will fix the bug and ignore GUIDs at all.