### PR TITLE
ignore role-changes performed by admins

### DIFF
--- a/fullstop-plugins/fullstop-unapproved-services-and-role-plugin/src/main/java/org/zalando/stups/fullstop/plugin/unapproved/UnapprovedServicesAndRolePlugin.java
+++ b/fullstop-plugins/fullstop-unapproved-services-and-role-plugin/src/main/java/org/zalando/stups/fullstop/plugin/unapproved/UnapprovedServicesAndRolePlugin.java
@@ -78,12 +78,13 @@ public class UnapprovedServicesAndRolePlugin extends AbstractFullstopPlugin {
     }
 
     private boolean isPerformedByAdmin(CloudTrailEventData eventData) {
+        final Set<String> adminRoles = unapprovedServicesAndRoleProperties.getAdminRoles();
         return Optional.ofNullable(eventData)
                 .map(CloudTrailEventData::getUserIdentity)
                 .map(UserIdentity::getSessionContext)
                 .map(SessionContext::getSessionIssuer)
                 .map(SessionIssuer::getUserName)
-                .filter(roleName -> roleName.equals(unapprovedServicesAndRoleProperties.getAdministrator()))
+                .filter(adminRoles::contains)
                 .isPresent();
     }
 

--- a/fullstop-plugins/fullstop-unapproved-services-and-role-plugin/src/main/java/org/zalando/stups/fullstop/plugin/unapproved/config/UnapprovedServicesAndRoleProperties.java
+++ b/fullstop-plugins/fullstop-unapproved-services-and-role-plugin/src/main/java/org/zalando/stups/fullstop/plugin/unapproved/config/UnapprovedServicesAndRoleProperties.java
@@ -3,8 +3,10 @@ package org.zalando.stups.fullstop.plugin.unapproved.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
 
 /**
  * @author mrandi
@@ -21,7 +23,7 @@ public class UnapprovedServicesAndRoleProperties {
 
     private List<String> eventNames = newArrayList();
 
-    private String administrator = "Shibboleth-Administrator";
+    private Set<String> adminRoles = newHashSet("Shibboleth-Administrator", "OrganizationAccountAccessRole");
 
     public List<String> getEventNames() {
         if (eventNames.isEmpty()) {
@@ -35,11 +37,11 @@ public class UnapprovedServicesAndRoleProperties {
         this.eventNames = eventNames;
     }
 
-    public String getAdministrator() {
-        return administrator;
+    public Set<String> getAdminRoles() {
+        return adminRoles;
     }
 
-    public void setAdministrator(String administrator) {
-        this.administrator = administrator;
+    public void setAdminRoles(Set<String> adminRoles) {
+        this.adminRoles = adminRoles;
     }
 }

--- a/fullstop-plugins/fullstop-unapproved-services-and-role-plugin/src/test/java/org/zalando/stups/fullstop/plugin/unapproved/UnapprovedServicesAndRolePluginTest.java
+++ b/fullstop-plugins/fullstop-unapproved-services-and-role-plugin/src/test/java/org/zalando/stups/fullstop/plugin/unapproved/UnapprovedServicesAndRolePluginTest.java
@@ -41,6 +41,7 @@ public class UnapprovedServicesAndRolePluginTest {
 
     private CloudTrailEvent event;
     private CloudTrailEvent adminEvent;
+    private CloudTrailEvent newAdminEvent;
 
     private UnapprovedServicesAndRolePlugin plugin;
 
@@ -52,6 +53,7 @@ public class UnapprovedServicesAndRolePluginTest {
 
         event = createCloudTrailEvent("/record.json");
         adminEvent = createCloudTrailEvent("/admin-record.json");
+        newAdminEvent = createCloudTrailEvent("/new-admin-record.json");
 
         plugin = new UnapprovedServicesAndRolePlugin(
                 policyProviderMock,
@@ -82,6 +84,11 @@ public class UnapprovedServicesAndRolePluginTest {
     @Test
     public void testSupportsAdminEvent() throws Exception {
         assertThat(plugin.supports(adminEvent)).isFalse();
+    }
+
+    @Test
+    public void testSupportsNewStyleAdminEvent() throws Exception {
+        assertThat(plugin.supports(newAdminEvent)).isFalse();
     }
 
     @Test

--- a/fullstop-plugins/fullstop-unapproved-services-and-role-plugin/src/test/resources/new-admin-record.json
+++ b/fullstop-plugins/fullstop-unapproved-services-and-role-plugin/src/test/resources/new-admin-record.json
@@ -1,0 +1,52 @@
+{
+  "Records": [
+    {
+      "eventVersion": "1.02",
+      "userIdentity": {
+        "arn": "arn:aws:sts::111222333444:assumed-role/OrganizationAccountAccessRole/1509091852018300305",
+        "type": "AssumedRole",
+        "accountId": "111222333444",
+        "accessKeyId": "ASIAIFJ67QTPAZNISOPA",
+        "principalId": "AROAI2T2TCK35EV3X46HY:1509091852018300305",
+        "sessionContext": {
+          "attributes": {
+            "creationDate": "2017-10-27T08:10:52Z",
+            "mfaAuthenticated": "false"
+          },
+          "sessionIssuer": {
+            "arn": "arn:aws:iam::111222333444:role/OrganizationAccountAccessRole",
+            "type": "Role",
+            "userName": "OrganizationAccountAccessRole",
+            "accountId": "111222333444",
+            "principalId": "AROAI2T2TCK35EV3X46HY"
+          }
+        }
+      },
+      "eventTime": "2015-06-17T15:45:40Z",
+      "eventSource": "iam.amazonaws.com",
+      "eventName": "CreateRole",
+      "awsRegion": "us-east-1",
+      "sourceIPAddress": "cloudformation.amazonaws.com",
+      "userAgent": "cloudformation.amazonaws.com",
+      "requestParameters": {
+        "path": "/",
+        "roleName": "mint-worker-b17-AppServerRole-W5WX8WewafwO2MEWZ",
+        "assumeRolePolicyDocument": "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Effect\":\"Allow\"}],\"Version\":\"2012-10-17\"}"
+      },
+      "responseElements": {
+        "role": {
+          "assumeRolePolicyDocument": "%7B%22Statement%22%3A%5B%7B%22Action%22%3A%5B%22sts%3AAssumeRole%22%5D%2C%22Principal%22%3A%7B%22Service%22%3A%5B%22ec2.amazonaws.com%22%5D%7D%2C%22Effect%22%3A%22Allow%22%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D",
+          "arn": "arn:aws:iam::XXXX123XXX:role/mint-worker-b17-AppServerRole-WX8WO2MEWZ",
+          "roleId": "FDSaffdsavr",
+          "createDate": "Jun 17, 2015 3:45:40 PM",
+          "roleName": "mint-worker-b17-AppServerRole-W58WO23MEWZ",
+          "path": "/"
+        }
+      },
+      "requestID": "e7ef6dssd9-1507-11e5-aaf6-fb10942b8a1f",
+      "eventID": "0eb03aae-2182-11e5-b5f7-727283247c7f",
+      "eventType": "AwsApiCall",
+      "recipientAccountId": "111222333444"
+    }
+  ]
+}


### PR DESCRIPTION
this change introduces a configurable list of administrator roles,
that can safely be ignored.

fixes #502 