### PR TITLE
fix possible NullPointerException

### DIFF
--- a/fullstop-plugins/fullstop-lambda-plugin/src/main/java/org/zalando/stups/fullstop/plugin/lambda/config/LambdaPluginProperties.java
+++ b/fullstop-plugins/fullstop-lambda-plugin/src/main/java/org/zalando/stups/fullstop/plugin/lambda/config/LambdaPluginProperties.java
@@ -1,25 +1,22 @@
 package org.zalando.stups.fullstop.plugin.lambda.config;
 
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
-import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
+import static com.google.common.collect.Lists.newArrayList;
 
 
 @ConfigurationProperties(prefix = "fullstop.plugins.lambda")
 public class LambdaPluginProperties {
 
-    private String s3Buckets;
+    private List<String> s3Buckets = newArrayList();
 
     public List<String> getS3Buckets() {
-        return Stream.of(s3Buckets.split(","))
-                .collect(toList());
+        return s3Buckets;
     }
 
-    public void setS3Buckets(final String s3Buckets) {
+    public void setS3Buckets(List<String> s3Buckets) {
         this.s3Buckets = s3Buckets;
     }
 }

--- a/fullstop-plugins/fullstop-lambda-plugin/src/test/java/org/zalando/stups/lambda/LambdaPluginTest.java
+++ b/fullstop-plugins/fullstop-lambda-plugin/src/test/java/org/zalando/stups/lambda/LambdaPluginTest.java
@@ -9,6 +9,7 @@ import org.zalando.stups.fullstop.plugin.lambda.config.LambdaPluginProperties;
 import org.zalando.stups.fullstop.violation.Violation;
 import org.zalando.stups.fullstop.violation.ViolationSink;
 
+import static java.util.Arrays.asList;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -30,7 +31,7 @@ public class LambdaPluginTest {
         mockViolationSink = mock(ViolationSink.class);
 
         lambdaPluginProperties = new LambdaPluginProperties();
-        lambdaPluginProperties.setS3Buckets("zalando-lambda-repository-eu-central-1,zalando-lambda-repository-eu-west-1");
+        lambdaPluginProperties.setS3Buckets(asList("zalando-lambda-repository-eu-central-1", "zalando-lambda-repository-eu-west-1"));
         lambdaPlugin = new LambdaPlugin(mockViolationSink, lambdaPluginProperties);
     }
 


### PR DESCRIPTION
LambdaProperties#getS3Buckets threw a NullPointerException, when no
config string was set.
This change replaces the manual comma-separated-value parsing with the
built-in Spring Boot functionality.