### PR TITLE
Testcontainers postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
-
 jdk: oraclejdk8
+
+sudo: required
+services:
+  - docker
 
 script:
     - mvn clean verify -Pintegration-test -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
 language: java
 
-sudo: true
-
 jdk: oraclejdk8
 
-addons:
-  postgresql: "9.4"
-
-before_script:
-  - psql -c 'CREATE DATABASE fullstop;' -U postgres
-#  - psql -c "ALTER USER postgres WITH PASSWORD 'postgres';" -U postgres
-
 script:
-    - mvn clean verify -Pintegration-test,pg-travis -U
+    - mvn clean verify -Pintegration-test -U
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Needs Java 1.8. Newer jdks are not supported yet.
 
     $ ./mvnw clean install
     
-## Run entire test suite
+## Run entire test suite (requires a local docker environment)
 
     $ ./mvnw clean verify -Pintegration-test
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ for encryption or you use Amazons [AWS CLI](http://docs.aws.amazon.com/cli/lates
 Needs Java 1.8. Newer jdks are not supported yet.
 
     $ ./mvnw clean install
+    
+## Run entire test suite
+
+    $ ./mvnw clean verify -Pintegration-test
 
 ## How to run
 

--- a/fullstop-it/pom.xml
+++ b/fullstop-it/pom.xml
@@ -10,7 +10,6 @@
     <artifactId>fullstop-it</artifactId>
 
     <properties>
-        <active-profiles>integration-test</active-profiles>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
@@ -25,6 +24,12 @@
             <groupId>org.zalando.stups</groupId>
             <artifactId>fullstop-logging</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -51,24 +56,12 @@
                         </executions>
                         <configuration>
                             <systemPropertyVariables>
-                                <spring.profiles.active>${active-profiles}</spring.profiles.active>
+                                <spring.profiles.active>integration-test</spring.profiles.active>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>pg-travis</id>
-            <properties>
-                <active-profiles>integration-test,travis</active-profiles>
-            </properties>
-        </profile>
-        <profile>
-            <id>gocd</id>
-            <properties>
-                <active-profiles>integration-test,gocd</active-profiles>
-            </properties>
         </profile>
     </profiles>
 </project>

--- a/fullstop-it/src/test/resources/config/application-gocd.yml
+++ b/fullstop-it/src/test/resources/config/application-gocd.yml
@@ -1,8 +1,0 @@
-spring:
-    datasource:
-        url: jdbc:postgresql:${DB_SUBNAME}
-        username: ${DB_USER}
-        password: ${DB_PASSWORD}
-        driver-class-name: org.postgresql.Driver
-    jpa:
-        database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/fullstop-it/src/test/resources/config/application-integration-test.yml
+++ b/fullstop-it/src/test/resources/config/application-integration-test.yml
@@ -3,10 +3,10 @@ spring:
         resource:
             tokenInfoUri: https://example.com/oauth/tokeninfo
     datasource:
-        url: jdbc:postgresql://localhost:5432/fullstop_test
+        url: jdbc:tc:postgresql:9://localhost/fullstop_test
         username: postgres
         password: postgres
-        driver-class-name: org.postgresql.Driver
+        driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
 
 fullstop:
 

--- a/fullstop-it/src/test/resources/config/application-travis.yml
+++ b/fullstop-it/src/test/resources/config/application-travis.yml
@@ -1,8 +1,0 @@
-spring:
-    datasource:
-        url: jdbc:postgresql://localhost:5432/fullstop
-        username: postgres
-        password: 
-        driver-class-name: org.postgresql.Driver
-    jpa:
-        database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/fullstop-violation/fullstop-violation-jpa/pom.xml
+++ b/fullstop-violation/fullstop-violation-jpa/pom.xml
@@ -94,8 +94,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/it/ApplicationLifecycleServiceImplIt.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/it/ApplicationLifecycleServiceImplIt.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.zalando.stups.fullstop.violation.EmbeddedPostgresJpaConfig;
+import org.zalando.stups.fullstop.violation.JpaConfig;
 import org.zalando.stups.fullstop.violation.entity.ApplicationEntity;
 import org.zalando.stups.fullstop.violation.entity.LifecycleEntity;
 import org.zalando.stups.fullstop.violation.entity.VersionEntity;
@@ -34,8 +34,8 @@ public class ApplicationLifecycleServiceImplIt {
     private static final String REGION = "eu-west-1";
     private static final String INSTANCE_ID = "i1";
     private static final DateTime INSTANCE_BOOT_TIME = now();
-    public static final String RUN_INSTANCES = "RunInstances";
-    public static final String TERMINATE_INSTANCES = "TerminateInstances";
+    private static final String RUN_INSTANCES = "RunInstances";
+    private static final String TERMINATE_INSTANCES = "TerminateInstances";
 
     @Autowired
     private ApplicationLifecycleService applicationLifecycleService;
@@ -54,7 +54,7 @@ public class ApplicationLifecycleServiceImplIt {
     }
 
     @Test
-    public void testNoOverwriteSame() throws Exception {
+    public void testNoOverwriteSame() {
         final LifecycleEntity taupgelifecycleEntity = new LifecycleEntity();
         taupgelifecycleEntity.setInstanceId(INSTANCE_ID);
         taupgelifecycleEntity.setAccountId(ACCOUNT_ID);
@@ -81,7 +81,7 @@ public class ApplicationLifecycleServiceImplIt {
     }
 
     @Test
-    public void testNoOverwriteDifferent() throws Exception {
+    public void testNoOverwriteDifferent() {
         final LifecycleEntity taupgelifecycleEntity = new LifecycleEntity();
         taupgelifecycleEntity.setInstanceId("97987");
         taupgelifecycleEntity.setAccountId(ACCOUNT_ID);
@@ -109,7 +109,7 @@ public class ApplicationLifecycleServiceImplIt {
 
 
     @Configuration
-    @Import(EmbeddedPostgresJpaConfig.class)
+    @Import(JpaConfig.class)
     static class TestConfig {
         @Bean
         ApplicationLifecycleService applicationLifecycleService() {

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/JpaConfig.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/JpaConfig.java
@@ -1,6 +1,5 @@
 package org.zalando.stups.fullstop.violation;
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
@@ -10,26 +9,13 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.retry.annotation.EnableRetry;
 
-import javax.sql.DataSource;
-import java.io.IOException;
-
 @Configuration
 @EnableAutoConfiguration
 @EnableJpaRepositories("org.zalando.stups.fullstop")
 @EntityScan("org.zalando.stups.fullstop")
 @EnableJpaAuditing
 @EnableRetry(proxyTargetClass = true)
-public class EmbeddedPostgresJpaConfig {
-
-    @Bean
-    DataSource dataSource() throws IOException {
-        return embeddedPostgres().getPostgresDatabase();
-    }
-
-    @Bean
-    EmbeddedPostgres embeddedPostgres() throws IOException {
-        return EmbeddedPostgres.start();
-    }
+public class JpaConfig {
 
     @Bean
     AuditorAware<String> auditorAware() {

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/repository/ApplicationRepositoryTest.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/repository/ApplicationRepositoryTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.zalando.stups.fullstop.violation.EmbeddedPostgresJpaConfig;
+import org.zalando.stups.fullstop.violation.JpaConfig;
 import org.zalando.stups.fullstop.violation.entity.ApplicationEntity;
 import org.zalando.stups.fullstop.violation.entity.LifecycleEntity;
 import org.zalando.stups.fullstop.violation.entity.VersionEntity;
@@ -20,7 +20,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = EmbeddedPostgresJpaConfig.class)
+@SpringBootTest(classes = JpaConfig.class)
 @Transactional
 public class ApplicationRepositoryTest {
 

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/repository/LifecycleRepositoryTest.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/repository/LifecycleRepositoryTest.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.zalando.stups.fullstop.violation.EmbeddedPostgresJpaConfig;
+import org.zalando.stups.fullstop.violation.JpaConfig;
 import org.zalando.stups.fullstop.violation.entity.ApplicationEntity;
 import org.zalando.stups.fullstop.violation.entity.LifecycleEntity;
 import org.zalando.stups.fullstop.violation.entity.VersionEntity;
@@ -27,7 +27,7 @@ import static org.springframework.data.domain.Sort.Direction.ASC;
  * Created by gkneitschel.
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = EmbeddedPostgresJpaConfig.class)
+@SpringBootTest(classes = JpaConfig.class)
 @Transactional
 public class LifecycleRepositoryTest {
 

--- a/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/repository/ViolationRepositoryTest.java
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/java/org/zalando/stups/fullstop/violation/repository/ViolationRepositoryTest.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.zalando.stups.fullstop.rule.entity.RuleEntity;
 import org.zalando.stups.fullstop.rule.repository.RuleEntityRepository;
-import org.zalando.stups.fullstop.violation.EmbeddedPostgresJpaConfig;
+import org.zalando.stups.fullstop.violation.JpaConfig;
 import org.zalando.stups.fullstop.violation.entity.CountByAccountAndType;
 import org.zalando.stups.fullstop.violation.entity.CountByAppVersionAndType;
 import org.zalando.stups.fullstop.violation.entity.ViolationEntity;
@@ -34,7 +34,7 @@ import static org.joda.time.DateTime.now;
 import static org.springframework.data.domain.Sort.Direction.ASC;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = EmbeddedPostgresJpaConfig.class)
+@SpringBootTest(classes = JpaConfig.class)
 @Transactional
 public class ViolationRepositoryTest {
 

--- a/fullstop-violation/fullstop-violation-jpa/src/test/resources/application.yaml
+++ b/fullstop-violation/fullstop-violation-jpa/src/test/resources/application.yaml
@@ -1,4 +1,9 @@
 spring:
+  datasource:
+    url: jdbc:tc:postgresql:9://localhost/fullstop_test
+    username: postgres
+    password: postgres
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   jpa:
     ## Toggle to print sql statements
     # show-sql: true

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <aws-java-sdk.version>1.11.356</aws-java-sdk.version>
         <wiremock.version>2.18.0</wiremock.version>
         <spring-cloud-netflix-dependencies.version>1.4.4.RELEASE</spring-cloud-netflix-dependencies.version>
+        <testcontainers.postgresql.version>1.8.0</testcontainers.postgresql.version>
     </properties>
 
     <modules>
@@ -255,6 +256,11 @@
                 <artifactId>wiremock</artifactId>
                 <version>${wiremock.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${testcontainers.postgresql.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <javax.interceptor-api.version>1.2.2</javax.interceptor-api.version>
         <assertj-assertions-generator-maven-plugin.version>2.1.0</assertj-assertions-generator-maven-plugin.version>
         <apt-maven-plugin.version>1.1.3</apt-maven-plugin.version>
-        <otj-pg-embedded.version>0.12.0</otj-pg-embedded.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <springfox-swagger.version>2.9.2</springfox-swagger.version>
         <stups-spring-oauth2.version>1.0.21</stups-spring-oauth2.version>
@@ -171,12 +170,6 @@
                 <version>${javax.interceptor-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.opentable.components</groupId>
-                <artifactId>otj-pg-embedded</artifactId>
-                <version>${otj-pg-embedded.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>javax.el</groupId>
                 <artifactId>javax.el-api</artifactId>
                 <version>${javax.el-api.version}</version>
@@ -261,6 +254,7 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${testcontainers.postgresql.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Use [testcontainers](https://www.testcontainers.org/) postgres in unit and integration tests.
This relieves us from having a postgres database available before running the (integration test suite). 

Requires a running and up-to-date docker environment.